### PR TITLE
Speeding up circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ workflows:
             - build_dgswemv2
       - run_parallel_correctness:
           requires:
-            - run_unit_tests
+            - build_dgswemv2
       - run_parallel_weirs:
           requires:
-            - run_unit_tests
+            - build_dgswemv2

--- a/scripts/correctness/test_parallel_correctness.sh
+++ b/scripts/correctness/test_parallel_correctness.sh
@@ -33,7 +33,7 @@ cp -r $DGSWEMV2_ROOT_/examples/manufactured_solution/input_files/* dgswemv2_test
 
 cd dgswemv2_test
 #Halve the manufactured solution run time to shorten circleci test time
-sed -i 's/  end_time: 3600                #in seconds/  end_time: 1800/g' dgswemv2_input.15
+sed -i 's/  end_time: 25-11-1987 01:00                /  end_time: 25-11-1987 00:30/g' dgswemv2_input.15
 $DGSWEMV2_ROOT_/build/mesh_generators/rectangular_mesh_generator mesh_generator_input.yml
 
 echo "Running Serial Test case..."


### PR DESCRIPTION
- fixes #83
- now correctly shortening the length the manufactured solution test case
- cleaning up `scripts/correctness/test_parallel_weirs.sh`
- allowing for parallel tests to run in parallel to unit tests