### PR TITLE
Wet dry fix

### DIFF
--- a/examples/rkdg_swe_manufactured_solution/input_files/mesh_generator_input.yml
+++ b/examples/rkdg_swe_manufactured_solution/input_files/mesh_generator_input.yml
@@ -39,16 +39,16 @@ pattern: 0
 # must additionally specify: frequency, forcing factor,
 # and the equilibrium argument
 # e.g.
-#  - type: flow # (x1,y1)--(x1,y2)
+#  - type: flow
 #    frequency: 0
 #    forcing_factor: 1
 #    equilibrium_argument: 0
 
 boundary:
   - type: land # (x1,y1)--(x2,y1)
-  - type: land # (x1,y1)--(x1,y2)
-  - type: land # (x1,y2)--(x2,y2)
   - type: land # (x2,y1)--(x2,y2)
+  - type: land # (x1,y2)--(x2,y2)
+  - type: land # (x1,y1)--(x1,y2)
 
 # The generated output mesh will be written to the following (path)/file
 # If this node is left empty, the default is set to recangular_mesh

--- a/mesh_generators/rectangular_mesh_generator.cpp
+++ b/mesh_generators/rectangular_mesh_generator.cpp
@@ -303,7 +303,9 @@ MeshGeneratorInput::MeshGeneratorInput(const std::string& input_string) : bounda
     if (yaml_input["boundary"]) {
         YAML::Node yaml_boundaries = yaml_input["boundary"];
         if (!(yaml_boundaries.IsSequence() && yaml_boundaries.size() == 4)) {
-            std::string err_msg{"Error: please check that the boundaries node is a sequence with 4 members"};
+            std::string err_msg{
+                "Error: please check that the boundaries node is a "
+                "sequence with 4 members"};
             throw std::logic_error(err_msg);
         }
 

--- a/mesh_generators/rectangular_mesh_generator.cpp
+++ b/mesh_generators/rectangular_mesh_generator.cpp
@@ -186,7 +186,7 @@ int main(int argc, const char* argv[]) {
 
     uint i = 1;
     for (uint n_bound = 0; n_bound < 4; n_bound++) {
-        if (boundaries[n_bound].type == 1) {
+        if (boundaries[n_bound].type == SWE::BoundaryTypes::tide) {
             file << boundaries[n_bound].nodes.size() << " = Number of nodes for open boundary " << i << '\n';
 
             std::for_each(boundaries[n_bound].nodes.begin(), boundaries[n_bound].nodes.end(), [&file](uint val) {
@@ -202,7 +202,7 @@ int main(int argc, const char* argv[]) {
 
     i = 1;
     for (uint n_bound = 0; n_bound < 4; n_bound++) {
-        if (boundaries[n_bound].type == 0) {
+        if (boundaries[n_bound].type == SWE::BoundaryTypes::land) {
             file << boundaries[n_bound].nodes.size() << " 0 = Number of nodes for land boundary " << i << '\n';
 
             std::for_each(boundaries[n_bound].nodes.begin(), boundaries[n_bound].nodes.end(), [&file](uint val) {
@@ -211,7 +211,7 @@ int main(int argc, const char* argv[]) {
 
             i++;
         }
-        if (boundaries[n_bound].type == 2) {
+        if (boundaries[n_bound].type == SWE::BoundaryTypes::flow) {
             file << boundaries[n_bound].nodes.size() << " 2 = Number of nodes for land boundary " << i << '\n';
 
             std::for_each(boundaries[n_bound].nodes.begin(), boundaries[n_bound].nodes.end(), [&file](uint val) {
@@ -239,7 +239,7 @@ void WriteBCISFile(const std::string& mesh_name, const std::vector<Boundary>& bo
             file << boundary.frequency << ' ' << boundary.forcing_factor << ' ' << boundary.equilibrium_argument
                  << '\n';
             for (uint node_id : boundary.nodes) {
-                file << node_id << ' ' << 0.0 << ' ' << 0.0 << '\n';
+                file << node_id << ' ' << 1.0 << ' ' << 0.0 << '\n';
             }
         }
     }

--- a/source/problem/SWE/discretization_RKDG/boundary_conditions/rkdg_swe_bc_land.hpp
+++ b/source/problem/SWE/discretization_RKDG/boundary_conditions/rkdg_swe_bc_land.hpp
@@ -24,11 +24,11 @@ class Land {
                      const HybMatrix<double, SWE::n_variables>& aux_in,
                      HybMatrix<double, SWE::n_variables>& F_hat);
 
-  void ComputeFlux(const RKStepper& stepper,
-                   const Column<HybMatrix<double, SWE::n_dimensions>>&& surface_normal,
-                   const Column<HybMatrix<double, SWE::n_variables>>&& q_in,
-                   const Column<HybMatrix<double, SWE::n_variables>>&& aux_in,
-                   Column<HybMatrix<double, SWE::n_variables>>&& F_hat);
+    void ComputeFlux(const RKStepper& stepper,
+                     const Column<HybMatrix<double, SWE::n_dimensions>>&& surface_normal,
+                     const Column<HybMatrix<double, SWE::n_variables>>&& q_in,
+                     const Column<HybMatrix<double, SWE::n_variables>>&& aux_in,
+                     Column<HybMatrix<double, SWE::n_variables>>&& F_hat);
 
     StatVector<double, SWE::n_variables> GetEX(const RKStepper& stepper,
                                                const StatVector<double, SWE::n_dimensions>& surface_normal,
@@ -82,16 +82,15 @@ void Land::ComputeFlux(const RKStepper& stepper,
     double t_x = -n_y;
     double t_y = n_x;
 
-    double qn_ex = -(q_in[SWE::Variables::qx]*n_x + q_in[SWE::Variables::qy]*n_y);
-    double qt_ex = q_in[SWE::Variables::qx]*t_x + q_in[SWE::Variables::qy]*t_y;
+    double qn_ex = -(q_in[SWE::Variables::qx] * n_x + q_in[SWE::Variables::qy] * n_y);
+    double qt_ex = q_in[SWE::Variables::qx] * t_x + q_in[SWE::Variables::qy] * t_y;
 
-    this->q_ex( SWE::Variables::ze, 0) = q_in[SWE::Variables::ze];
-    this->q_ex( SWE::Variables::qx, 0) = qn_ex* n_x + qt_ex* t_x;
-    this->q_ex( SWE::Variables::qy, 0) = qn_ex* n_y + qt_ex* t_y;
+    this->q_ex(SWE::Variables::ze, 0) = q_in[SWE::Variables::ze];
+    this->q_ex(SWE::Variables::qx, 0) = qn_ex * n_x + qt_ex * t_x;
+    this->q_ex(SWE::Variables::qy, 0) = qn_ex * n_y + qt_ex * t_y;
 
     F_hat = LLF_flux(Global::g, q_in, this->q_ex, aux_in, surface_normal);
 }
-
 
 StatVector<double, SWE::n_variables> Land::GetEX(const RKStepper& stepper,
                                                  const StatVector<double, SWE::n_dimensions>& surface_normal,

--- a/source/problem/SWE/discretization_RKDG/boundary_conditions/rkdg_swe_bc_land.hpp
+++ b/source/problem/SWE/discretization_RKDG/boundary_conditions/rkdg_swe_bc_land.hpp
@@ -25,7 +25,7 @@ class Land {
                      HybMatrix<double, SWE::n_variables>& F_hat);
 
     void ComputeFlux(const RKStepper& stepper,
-                     const StatVector<double, SWE::n_dimensions>& surface_normal
+                     const StatVector<double, SWE::n_dimensions>& surface_normal,
                      const StatVector<double, SWE::n_variables>& q_in,
                      const StatVector<double, SWE::n_auxiliaries>& aux_in,
                      StatVector<double, SWE::n_variables>&& F_hat);
@@ -72,7 +72,7 @@ void Land::ComputeFlux(const RKStepper& stepper,
 }
 
 void Land::ComputeFlux(const RKStepper& stepper,
-                       const StatVector<double, SWE::n_dimensions>& surface_normal
+                       const StatVector<double, SWE::n_dimensions>& surface_normal,
                        const StatVector<double, SWE::n_variables>& q_in,
                        const StatVector<double, SWE::n_auxiliaries>& aux_in,
                        StatVector<double, SWE::n_variables>&& F_hat) {

--- a/source/problem/SWE/discretization_RKDG/boundary_conditions/rkdg_swe_bc_land.hpp
+++ b/source/problem/SWE/discretization_RKDG/boundary_conditions/rkdg_swe_bc_land.hpp
@@ -24,6 +24,12 @@ class Land {
                      const HybMatrix<double, SWE::n_variables>& aux_in,
                      HybMatrix<double, SWE::n_variables>& F_hat);
 
+  void ComputeFlux(const RKStepper& stepper,
+                   const Column<HybMatrix<double, SWE::n_dimensions>>&& surface_normal,
+                   const Column<HybMatrix<double, SWE::n_variables>>&& q_in,
+                   const Column<HybMatrix<double, SWE::n_variables>>&& aux_in,
+                   Column<HybMatrix<double, SWE::n_variables>>&& F_hat);
+
     StatVector<double, SWE::n_variables> GetEX(const RKStepper& stepper,
                                                const StatVector<double, SWE::n_dimensions>& surface_normal,
                                                const StatVector<double, SWE::n_variables>& q_in);
@@ -64,6 +70,28 @@ void Land::ComputeFlux(const RKStepper& stepper,
             Global::g, column(q_in, gp), column(this->q_ex, gp), column(aux_in, gp), column(surface_normal, gp));
     }
 }
+
+void Land::ComputeFlux(const RKStepper& stepper,
+                       const Column<HybMatrix<double, SWE::n_dimensions>>&& surface_normal,
+                       const Column<HybMatrix<double, SWE::n_variables>>&& q_in,
+                       const Column<HybMatrix<double, SWE::n_variables>>&& aux_in,
+                       Column<HybMatrix<double, SWE::n_variables>>&& F_hat) {
+    // *** //
+    double n_x = surface_normal[GlobalCoord::x];
+    double n_y = surface_normal[GlobalCoord::y];
+    double t_x = -n_y;
+    double t_y = n_x;
+
+    double qn_ex = -(q_in[SWE::Variables::qx]*n_x + q_in[SWE::Variables::qy]*n_y);
+    double qt_ex = q_in[SWE::Variables::qx]*t_x + q_in[SWE::Variables::qy]*t_y;
+
+    this->q_ex( SWE::Variables::ze, 0) = q_in[SWE::Variables::ze];
+    this->q_ex( SWE::Variables::qx, 0) = qn_ex* n_x + qt_ex* t_x;
+    this->q_ex( SWE::Variables::qy, 0) = qn_ex* n_y + qt_ex* t_y;
+
+    F_hat = LLF_flux(Global::g, q_in, this->q_ex, aux_in, surface_normal);
+}
+
 
 StatVector<double, SWE::n_variables> Land::GetEX(const RKStepper& stepper,
                                                  const StatVector<double, SWE::n_dimensions>& surface_normal,

--- a/source/problem/SWE/discretization_RKDG/boundary_conditions/rkdg_swe_bc_land.hpp
+++ b/source/problem/SWE/discretization_RKDG/boundary_conditions/rkdg_swe_bc_land.hpp
@@ -25,10 +25,10 @@ class Land {
                      HybMatrix<double, SWE::n_variables>& F_hat);
 
     void ComputeFlux(const RKStepper& stepper,
-                     const Column<HybMatrix<double, SWE::n_dimensions>>&& surface_normal,
-                     const Column<HybMatrix<double, SWE::n_variables>>&& q_in,
-                     const Column<HybMatrix<double, SWE::n_variables>>&& aux_in,
-                     Column<HybMatrix<double, SWE::n_variables>>&& F_hat);
+                     const StatVector<double, SWE::n_dimensions>& surface_normal
+                     const StatVector<double, SWE::n_variables>& q_in,
+                     const StatVector<double, SWE::n_auxiliaries>& aux_in,
+                     StatVector<double, SWE::n_variables>&& F_hat);
 
     StatVector<double, SWE::n_variables> GetEX(const RKStepper& stepper,
                                                const StatVector<double, SWE::n_dimensions>& surface_normal,
@@ -72,10 +72,10 @@ void Land::ComputeFlux(const RKStepper& stepper,
 }
 
 void Land::ComputeFlux(const RKStepper& stepper,
-                       const Column<HybMatrix<double, SWE::n_dimensions>>&& surface_normal,
-                       const Column<HybMatrix<double, SWE::n_variables>>&& q_in,
-                       const Column<HybMatrix<double, SWE::n_variables>>&& aux_in,
-                       Column<HybMatrix<double, SWE::n_variables>>&& F_hat) {
+                       const StatVector<double, SWE::n_dimensions>& surface_normal
+                       const StatVector<double, SWE::n_variables>& q_in,
+                       const StatVector<double, SWE::n_auxiliaries>& aux_in,
+                       StatVector<double, SWE::n_variables>&& F_hat) {
     // *** //
     double n_x = surface_normal[GlobalCoord::x];
     double n_y = surface_normal[GlobalCoord::y];

--- a/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_wet_dry.hpp
+++ b/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_wet_dry.hpp
@@ -14,8 +14,8 @@ struct WetDry {
           h_at_vrtx(nvrtx),
           h_at_vrtx_temp(nvrtx) {}
 
-    bool wet;
-    bool went_completely_dry;
+    bool wet = true;
+    bool went_completely_dry = false;
 
     double bath_min;
 

--- a/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_wet_dry.hpp
+++ b/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_wet_dry.hpp
@@ -14,7 +14,7 @@ struct WetDry {
           h_at_vrtx(nvrtx),
           h_at_vrtx_temp(nvrtx) {}
 
-    bool wet = true;
+    bool wet                 = true;
     bool went_completely_dry = false;
 
     double bath_min;

--- a/source/problem/SWE/discretization_RKDG/interface_specializations/rkdg_swe_is_internal.hpp
+++ b/source/problem/SWE/discretization_RKDG/interface_specializations/rkdg_swe_is_internal.hpp
@@ -38,77 +38,63 @@ void Internal::ComputeFlux(const RKStepper& stepper, InterfaceType& intface) {
                                                        column(intface.surface_normal_in, gp));
 
         column(boundary_ex.F_hat_at_gp, gp_ex) = -column(boundary_in.F_hat_at_gp, gp);
-    }
 
-    // compute net volume flux out of IN/EX elements
-    double net_volume_flux_in = 0;
-    // double net_volume_flux_ex = 0;
-
-    net_volume_flux_in = intface.IntegrationIN(boundary_in.F_hat_at_gp)[SWE::Variables::ze];
-    // net_volume_flux_ex = -net_volume_flux_in;
-
-    if (net_volume_flux_in > 0) {
-        if (!wet_in) {  // water flowing from dry IN element
+        //fix me: Place wet states on the outside
+        if (boundary_in.F_hat_at_gp(Variables::ze,gp) > 1e-12) {
+          if (!wet_in) {  // water flowing from dry IN element
             // Zero flux on IN element side
-            set_constant(boundary_in.F_hat_at_gp, 0.0);
+            set_constant(column(boundary_in.F_hat_at_gp,gp), 0.0);
 
             // Reflective Boundary on EX element side
             BC::Land land_boundary;
-            land_boundary.Initialize(intface.data_ex.get_ngp_boundary(intface.bound_id_ex));
+            land_boundary.Initialize(1);
 
             land_boundary.ComputeFlux(stepper,
-                                      intface.surface_normal_ex,
-                                      boundary_ex.q_at_gp,
-                                      boundary_ex.aux_at_gp,
-                                      boundary_ex.F_hat_at_gp);
+                                      column(intface.surface_normal_ex,gp_ex),
+                                      column(boundary_ex.q_at_gp,gp_ex),
+                                      column(boundary_ex.aux_at_gp, gp_ex),
+                                      column(boundary_ex.F_hat_at_gp,gp_ex));
 
-            net_volume_flux_in = 0;
-            // net_volume_flux_ex = 0;
-        } else if (!wet_ex) {  // water flowing to dry EX element
-            for (uint gp = 0; gp < intface.data_in.get_ngp_boundary(intface.bound_id_in); ++gp) {
-                gp_ex = ngp - gp - 1;
 
-                column(boundary_ex.F_hat_at_gp, gp_ex) = LLF_flux(0.0,
-                                                                  column(boundary_ex.q_at_gp, gp_ex),
-                                                                  column(boundary_in.q_at_gp, gp),
-                                                                  column(boundary_ex.aux_at_gp, gp_ex),
-                                                                  column(intface.surface_normal_ex, gp_ex));
-            }
+          } else if (!wet_ex) {  // water flowing to dry EX element
 
-            net_volume_flux_in = intface.IntegrationIN(boundary_in.F_hat_at_gp)[SWE::Variables::ze];
-            // net_volume_flux_ex = intface.IntegrationEX(boundary_ex.ze_numerical_flux_at_gp);
-        }
-    } else if (net_volume_flux_in < 0) {
-        if (!wet_ex) {  // water flowing from dry EX element
+              column(boundary_ex.F_hat_at_gp, gp_ex) = LLF_flux(0.0,
+                                                                column(boundary_ex.q_at_gp, gp_ex),
+                                                                column(boundary_in.q_at_gp, gp),
+                                                                column(boundary_ex.aux_at_gp, gp_ex),
+                                                                column(intface.surface_normal_ex, gp_ex));
+
+              //Only remove gravity contributions for the momentum fluxes
+              boundary_ex.F_hat_at_gp(Variables::ze,gp_ex) = -boundary_in.F_hat_at_gp(Variables::ze,gp);
+          }
+        } else if (boundary_in.F_hat_at_gp(Variables::ze,gp) < -1e-12) {
+          if (!wet_ex) {  // water flowing from dry EX element
             // Zero flux on EX element side
-            set_constant(boundary_ex.F_hat_at_gp, 0.0);
+            set_constant(column(boundary_ex.F_hat_at_gp,gp_ex), 0.0);
 
             // Reflective Boundary on IN element side
             BC::Land land_boundary;
-            land_boundary.Initialize(intface.data_in.get_ngp_boundary(intface.bound_id_in));
+            land_boundary.Initialize(1);
 
             land_boundary.ComputeFlux(stepper,
-                                      intface.surface_normal_in,
-                                      boundary_in.q_at_gp,
-                                      boundary_in.aux_at_gp,
-                                      boundary_in.F_hat_at_gp);
+                                      column(intface.surface_normal_in,gp),
+                                      column(boundary_in.q_at_gp,gp),
+                                      column(boundary_in.aux_at_gp,gp),
+                                      column(boundary_in.F_hat_at_gp,gp));
 
-            net_volume_flux_in = 0;
-            // net_volume_flux_ex = 0;
-        } else if (!wet_in) {  // water flowing to dry IN element
-            for (uint gp = 0; gp < intface.data_in.get_ngp_boundary(intface.bound_id_in); ++gp) {
-                gp_ex = ngp - gp - 1;
+          } else if (!wet_in) {  // water flowing to dry IN element
 
-                column(boundary_in.F_hat_at_gp, gp) = LLF_flux(0.0,
-                                                               column(boundary_in.q_at_gp, gp),
-                                                               column(boundary_ex.q_at_gp, gp_ex),
-                                                               column(boundary_in.aux_at_gp, gp),
-                                                               column(intface.surface_normal_in, gp));
-            }
+              column(boundary_in.F_hat_at_gp, gp) = LLF_flux(0.0,
+                                                             column(boundary_in.q_at_gp, gp),
+                                                             column(boundary_ex.q_at_gp, gp_ex),
+                                                             column(boundary_in.aux_at_gp, gp),
+                                                             column(intface.surface_normal_in, gp));
 
-            net_volume_flux_in = intface.IntegrationIN(boundary_in.F_hat_at_gp)[SWE::Variables::ze];
-            // net_volume_flux_ex = intface.IntegrationEX(boundary_ex.ze_numerical_flux_at_gp);
+              boundary_in.F_hat_at_gp(Variables::ze,gp) = - boundary_ex.F_hat_at_gp(Variables::ze,gp_ex);
+          }
         }
+
+        assert( !std::isnan(boundary_in.F_hat_at_gp(Variables::ze,gp))  );
     }
 }
 }

--- a/source/problem/SWE/discretization_RKDG/kernels_preprocessor/rkdg_swe_pre_init_data.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_preprocessor/rkdg_swe_pre_init_data.hpp
@@ -90,8 +90,7 @@ void Problem::initialize_data_kernel(ProblemMeshType& mesh, const ProblemInputTy
 
         row(boundary_in.aux_at_gp, SWE::Auxiliaries::bath) = intface.ComputeNodalUgpIN(bathymetry);
 
-
-        //bathymetry is not necessarily continuous across weir nodes
+        // bathymetry is not necessarily continuous across weir nodes
         for (uint node_id = 0; node_id < nnode; ++node_id) {
             bathymetry[node_id] = shape_ex.nodal_coordinates[node_id][GlobalCoord::z];
         }

--- a/source/problem/SWE/discretization_RKDG/kernels_preprocessor/rkdg_swe_pre_init_data.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_preprocessor/rkdg_swe_pre_init_data.hpp
@@ -74,6 +74,7 @@ void Problem::initialize_data_kernel(ProblemMeshType& mesh, const ProblemInputTy
 
     mesh.CallForEachInterface([&problem_specific_input](auto& intface) {
         auto& shape_in = intface.GetShapeIN();
+        auto& shape_ex = intface.GetShapeEX();
 
         auto& boundary_in = intface.data_in.boundary[intface.bound_id_in];
         auto& boundary_ex = intface.data_ex.boundary[intface.bound_id_ex];
@@ -89,12 +90,13 @@ void Problem::initialize_data_kernel(ProblemMeshType& mesh, const ProblemInputTy
 
         row(boundary_in.aux_at_gp, SWE::Auxiliaries::bath) = intface.ComputeNodalUgpIN(bathymetry);
 
-        uint gp_ex;
-        for (uint gp = 0; gp < ngp; gp++) {
-            gp_ex = ngp - gp - 1;
 
-            boundary_ex.aux_at_gp(SWE::Auxiliaries::bath, gp_ex) = boundary_in.aux_at_gp(SWE::Auxiliaries::bath, gp);
+        //bathymetry is not necessarily continuous across weir nodes
+        for (uint node_id = 0; node_id < nnode; ++node_id) {
+            bathymetry[node_id] = shape_ex.nodal_coordinates[node_id][GlobalCoord::z];
         }
+
+        row(boundary_ex.aux_at_gp, SWE::Auxiliaries::bath) = intface.ComputeNodalUgpEX(bathymetry);
 
         if (problem_specific_input.spherical_projection.type == SWE::SphericalProjectionType::Enable) {
             DynRowVector<double> y_node(nnode);

--- a/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_serial_stage.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_serial_stage.hpp
@@ -23,15 +23,15 @@ void Problem::serial_stage_kernel(const RKStepper& stepper, ProblemDiscretizatio
         bool nan_found = Problem::scrutinize_solution_kernel(stepper, elt);
 
         if (nan_found)
+            std::cerr << "Fatal Error: NaN found at element " << elt.GetID() << '\n';
             abort();
     });
 
-    if (SWE::PostProcessing::slope_limiting) {
-        if (SWE::PostProcessing::wetting_drying) {
-            discretization.mesh.CallForEachElement(
-                [&stepper](auto& elt) { Problem::wetting_drying_kernel(stepper, elt); });
-        }
+    if (SWE::PostProcessing::wetting_drying) {
+        discretization.mesh.CallForEachElement([&stepper](auto& elt) { Problem::wetting_drying_kernel(stepper, elt); });
+    }
 
+    if (SWE::PostProcessing::slope_limiting) {
         discretization.mesh.CallForEachElement(
             [&stepper](auto& elt) { Problem::slope_limiting_prepare_element_kernel(stepper, elt); });
 
@@ -44,9 +44,6 @@ void Problem::serial_stage_kernel(const RKStepper& stepper, ProblemDiscretizatio
         discretization.mesh.CallForEachElement([&stepper](auto& elt) { Problem::slope_limiting_kernel(stepper, elt); });
     }
 
-    if (SWE::PostProcessing::wetting_drying) {
-        discretization.mesh.CallForEachElement([&stepper](auto& elt) { Problem::wetting_drying_kernel(stepper, elt); });
-    }
 }
 }
 }

--- a/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_serial_stage.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_serial_stage.hpp
@@ -23,10 +23,10 @@ void Problem::serial_stage_kernel(const RKStepper& stepper, ProblemDiscretizatio
         bool nan_found = Problem::scrutinize_solution_kernel(stepper, elt);
 
         if (nan_found) {
-          std::cerr << "Fatal Error: NaN found at element " << elt.GetID() << std::endl;
-          abort();
+            std::cerr << "Fatal Error: NaN found at element " << elt.GetID() << std::endl;
+            abort();
         }
-      });
+    });
 
     if (SWE::PostProcessing::wetting_drying) {
         discretization.mesh.CallForEachElement([&stepper](auto& elt) { Problem::wetting_drying_kernel(stepper, elt); });
@@ -44,7 +44,6 @@ void Problem::serial_stage_kernel(const RKStepper& stepper, ProblemDiscretizatio
 
         discretization.mesh.CallForEachElement([&stepper](auto& elt) { Problem::slope_limiting_kernel(stepper, elt); });
     }
-
 }
 }
 }

--- a/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_serial_stage.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_serial_stage.hpp
@@ -22,10 +22,11 @@ void Problem::serial_stage_kernel(const RKStepper& stepper, ProblemDiscretizatio
     discretization.mesh.CallForEachElement([&stepper](auto& elt) {
         bool nan_found = Problem::scrutinize_solution_kernel(stepper, elt);
 
-        if (nan_found)
-            std::cerr << "Fatal Error: NaN found at element " << elt.GetID() << '\n';
-            abort();
-    });
+        if (nan_found) {
+          std::cerr << "Fatal Error: NaN found at element " << elt.GetID() << std::endl;
+          abort();
+        }
+      });
 
     if (SWE::PostProcessing::wetting_drying) {
         discretization.mesh.CallForEachElement([&stepper](auto& elt) { Problem::wetting_drying_kernel(stepper, elt); });

--- a/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_update.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_update.hpp
@@ -56,7 +56,7 @@ bool Problem::scrutinize_solution_kernel(const RKStepper& stepper, ElementType& 
     }
 
     for (uint dof = 0; dof < ndof; ++dof) {
-        if (std::isnan(state.q(SWE::Variables::qx, dof))) {
+        if (std::isnan(state.q(SWE::Variables::qy, dof))) {
             std::cerr << "Error: found isnan qy at Element " << elt.GetID();
             std::cerr << "       At stage: " << stage << "\n";
 

--- a/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_volume.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_volume.hpp
@@ -6,10 +6,12 @@ namespace RKDG {
 template <typename ElementType>
 void Problem::volume_kernel(const RKStepper& stepper, ElementType& elt) {
     const uint stage = stepper.GetStage();
+
     auto& wd_state   = elt.data.wet_dry_state;
     auto& state      = elt.data.state[stage];
 
     set_constant(state.rhs, 0.0);
+    
     if (wd_state.wet) {
         auto& internal = elt.data.internal;
 

--- a/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_volume.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_volume.hpp
@@ -6,8 +6,8 @@ namespace RKDG {
 template <typename ElementType>
 void Problem::volume_kernel(const RKStepper& stepper, ElementType& elt) {
     const uint stage = stepper.GetStage();
-    auto& wd_state = elt.data.wet_dry_state;
-    auto& state    = elt.data.state[stepper.GetStage()];
+    auto& wd_state   = elt.data.wet_dry_state;
+    auto& state      = elt.data.state[stage];
 
     set_constant(state.rhs, 0.0);
     if (wd_state.wet) {

--- a/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_volume.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_volume.hpp
@@ -5,12 +5,12 @@ namespace SWE {
 namespace RKDG {
 template <typename ElementType>
 void Problem::volume_kernel(const RKStepper& stepper, ElementType& elt) {
+    const uint stage = stepper.GetStage();
     auto& wd_state = elt.data.wet_dry_state;
+    auto& state    = elt.data.state[stepper.GetStage()];
 
+    set_constant(state.rhs, 0.0);
     if (wd_state.wet) {
-        const uint stage = stepper.GetStage();
-
-        auto& state    = elt.data.state[stage];
         auto& internal = elt.data.internal;
 
         internal.q_at_gp = elt.ComputeUgp(state.q);

--- a/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_wet_dry.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_processor/rkdg_swe_proc_wet_dry.hpp
@@ -9,51 +9,59 @@ void Problem::wetting_drying_kernel(const RKStepper& stepper, ElementType& elt) 
 
     auto& state    = elt.data.state[stage + 1];
     auto& wd_state = elt.data.wet_dry_state;
+    uint number_of_dry_nodes = 0;
+    wd_state.went_completely_dry = false;
 
+    //fixme: think about higher degree polynomials here (c.f. issue #107)
     wd_state.q_lin     = elt.ProjectBasisToLinear(state.q);
     wd_state.q_at_vrtx = elt.ComputeLinearUvrtx(wd_state.q_lin);
 
     for (uint vrtx = 0; vrtx < elt.data.get_nvrtx(); vrtx++) {
         wd_state.h_at_vrtx[vrtx] = wd_state.q_at_vrtx(SWE::Variables::ze, vrtx) + wd_state.bath_at_vrtx[vrtx];
+
+        if ( wd_state.h_at_vrtx[vrtx] <= PostProcessing::h_o + PostProcessing::h_o_threshold) {
+            ++number_of_dry_nodes;
+        }
     }
 
     double h_avg = std::accumulate(wd_state.h_at_vrtx.begin(), wd_state.h_at_vrtx.end(), 0.0) / elt.data.get_nvrtx();
+    if ( h_avg <= PostProcessing::h_o_threshold ) {
+        wd_state.went_completely_dry = true;
+        h_avg = PostProcessing::h_o_threshold;
+    }
 
     bool set_wet_element = false;
     bool set_dry_element = false;
     bool check_element   = false;
-
-    if (h_avg <= PostProcessing::h_o + PostProcessing::h_o_threshold) {
-        // Say that "low" h_avg is 10% of h_o
-        // Check if element has dangerously low h_avg or even negative h_avg
-        // In this case we need to bump up the water to at least "low" h_avg
-        if (h_avg < 0.1 * PostProcessing::h_o) {
-            wd_state.went_completely_dry = true;
-
-            h_avg = 0.1 * PostProcessing::h_o;
+    if (number_of_dry_nodes==0) {
+        if ( wd_state.wet ) {
+            return;
+        } else {
+            check_element = true;
         }
-
+    } else if (number_of_dry_nodes==wd_state.h_at_vrtx.size()) {
         for (uint vrtx = 0; vrtx < elt.data.get_nvrtx(); vrtx++) {
             wd_state.q_at_vrtx(SWE::Variables::ze, vrtx) = h_avg - wd_state.bath_at_vrtx[vrtx];
+            wd_state.q_at_vrtx(SWE::Variables::qx, vrtx) = 0.0;
+            wd_state.q_at_vrtx(SWE::Variables::qy, vrtx) = 0.0;
         }
 
-        set_dry_element = true;
+        wd_state.wet = false;
+
+        state.q = elt.ProjectLinearToBasis(elt.data.get_ndof(), wd_state.q_at_vrtx);
+
+        set_constant(state.rhs, 0.0);
+
+        return;
     } else {
-        uint n_dry_vrtx = 0;
-
-        for (uint vrtx = 0; vrtx < elt.data.get_nvrtx(); vrtx++) {
-            if (wd_state.h_at_vrtx[vrtx] <= PostProcessing::h_o + PostProcessing::h_o_threshold) {
-                n_dry_vrtx++;
-            }
-        }
-
-        if (n_dry_vrtx == 0) {
-            if (wd_state.wet) {
-                set_wet_element = true;
-            } else {
-                check_element = true;
+        if ( h_avg <= PostProcessing::h_o + PostProcessing::h_o_threshold ) {
+            for (uint vrtx = 0; vrtx < elt.data.get_nvrtx(); vrtx++) {
+                wd_state.q_at_vrtx(SWE::Variables::ze, vrtx) = h_avg - wd_state.bath_at_vrtx[vrtx];
+                wd_state.q_at_vrtx(SWE::Variables::qx, vrtx) = 0;
+                wd_state.q_at_vrtx(SWE::Variables::qy, vrtx) = 0;
             }
         } else {
+
             auto h_min_iter = std::min_element(wd_state.h_at_vrtx.begin(), wd_state.h_at_vrtx.end());
             uint h_min_vrtx = std::distance(wd_state.h_at_vrtx.begin(), h_min_iter);
 
@@ -67,7 +75,7 @@ void Problem::wetting_drying_kernel(const RKStepper& stepper, ElementType& elt) 
             wd_state.h_at_vrtx_temp[h_mid_vrtx] =
                 std::max(PostProcessing::h_o,
                          wd_state.h_at_vrtx[h_mid_vrtx] -
-                             (wd_state.h_at_vrtx_temp[h_min_vrtx] - wd_state.h_at_vrtx[h_min_vrtx]) / 2);
+                         (wd_state.h_at_vrtx_temp[h_min_vrtx] - wd_state.h_at_vrtx[h_min_vrtx]) / 2);
 
             wd_state.h_at_vrtx_temp[h_max_vrtx] =
                 wd_state.h_at_vrtx[h_max_vrtx] -
@@ -79,7 +87,7 @@ void Problem::wetting_drying_kernel(const RKStepper& stepper, ElementType& elt) 
             double del_qx = 0;
             double del_qy = 0;
 
-            n_dry_vrtx = 0;
+            uint n_dry_vrtx = 0;
             for (uint vrtx = 0; vrtx < elt.data.get_nvrtx(); vrtx++) {
                 if (wd_state.h_at_vrtx[vrtx] <= PostProcessing::h_o + PostProcessing::h_o_threshold) {
                     n_dry_vrtx++;
@@ -92,6 +100,8 @@ void Problem::wetting_drying_kernel(const RKStepper& stepper, ElementType& elt) 
                 }
             }
 
+            assert( n_dry_vrtx < 3 );
+
             for (uint vrtx = 0; vrtx < elt.data.get_nvrtx(); vrtx++) {
                 wd_state.q_at_vrtx(SWE::Variables::ze, vrtx) = wd_state.h_at_vrtx[vrtx] - wd_state.bath_at_vrtx[vrtx];
 
@@ -100,29 +110,26 @@ void Problem::wetting_drying_kernel(const RKStepper& stepper, ElementType& elt) 
                     wd_state.q_at_vrtx(SWE::Variables::qy, vrtx) += del_qy / (3 - n_dry_vrtx);
                 }
             }
-
-            state.q = elt.ProjectLinearToBasis(elt.data.get_ndof(), wd_state.q_at_vrtx);
-
-            if (wd_state.wet) {
-                set_wet_element = true;
-            } else {
-                check_element = true;
-            }
         }
 
-        if (check_element) {
-            auto h_max_iter = std::max_element(wd_state.h_at_vrtx.begin(), wd_state.h_at_vrtx.end());
-            uint h_max_vrtx = std::distance(wd_state.h_at_vrtx.begin(), h_max_iter);
+        state.q = elt.ProjectLinearToBasis(elt.data.get_ndof(), wd_state.q_at_vrtx);
 
-            double ze_h_max_vrtx = wd_state.q_at_vrtx(SWE::Variables::ze, h_max_vrtx);
-
-            if (ze_h_max_vrtx > PostProcessing::h_o - wd_state.bath_min) {
-                set_wet_element = true;
-            } else {
-                set_dry_element = true;
-            }
-        };
+        check_element = true;
     }
+
+    if (check_element) {
+        auto h_max_iter = std::max_element(wd_state.h_at_vrtx.begin(), wd_state.h_at_vrtx.end());
+        uint h_max_vrtx = std::distance(wd_state.h_at_vrtx.begin(), h_max_iter);
+
+        double ze_h_max_vrtx = wd_state.q_at_vrtx(SWE::Variables::ze, h_max_vrtx);
+
+        if (ze_h_max_vrtx > PostProcessing::h_o - wd_state.bath_min) {
+            set_wet_element = true;
+        } else {
+            set_dry_element = true;
+        }
+    }
+
 
     if (set_dry_element) {
         wd_state.wet = false;

--- a/source/problem/SWE/swe_definitions.hpp
+++ b/source/problem/SWE/swe_definitions.hpp
@@ -30,7 +30,7 @@ static bool wetting_drying = false;
 static bool slope_limiting = false;
 
 static double h_o           = 0.1;
-static double h_o_threshold = 1.0e5 * std::numeric_limits<double>::epsilon();
+static double h_o_threshold = 1.0e-6;
 
 // Cockburn-Shu SL parameters
 static double M  = 1.0e-8;

--- a/source/utilities/linear_algebra/use_blaze.hpp
+++ b/source/utilities/linear_algebra/use_blaze.hpp
@@ -25,6 +25,8 @@ template <typename T>
 using DynMatrix = blaze::DynamicMatrix<T>;
 template <typename T, uint m>
 using HybMatrix = blaze::HybridMatrix<T, m, 16>;
+template <typename Matrix>
+using HybColumnType = decltype( blaze::column<1UL>( std::declval<Matrix>() ) );
 
 template <typename T>
 using SparseVector = blaze::CompressedVector<T>;

--- a/source/utilities/linear_algebra/use_blaze.hpp
+++ b/source/utilities/linear_algebra/use_blaze.hpp
@@ -26,7 +26,7 @@ using DynMatrix = blaze::DynamicMatrix<T>;
 template <typename T, uint m>
 using HybMatrix = blaze::HybridMatrix<T, m, 16>;
 template <typename Matrix>
-using HybColumnType = decltype( blaze::column<1UL>( std::declval<Matrix>() ) );
+using HybColumnType = decltype(blaze::column<1UL>(std::declval<Matrix>()));
 
 template <typename T>
 using SparseVector = blaze::CompressedVector<T>;

--- a/source/utilities/linear_algebra/use_eigen.hpp
+++ b/source/utilities/linear_algebra/use_eigen.hpp
@@ -23,6 +23,8 @@ template <typename T>
 using DynMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 template <typename T, uint m>
 using HybMatrix = Eigen::Matrix<T, m, Eigen::Dynamic>;
+template <typename Matrix>
+using Column = typename Eigen::DenseBase<Matrix>::ColXpr;
 
 template <typename T>
 using SparseMatrix = Eigen::SparseMatrix<T>;


### PR DESCRIPTION
Over all the wetting and drying algorithm now much more closely
resembles the version implemented in `dgswem`. This is most prevalent in
changes to the interface kernel term, where various flux limiting
strategies have been implemented. The other major fix was the 0-ing of
the right hand side for dry elements. These contributions were
erroneously being kept from previous iterations.