### PR TITLE
Using length of send buffer to deduce number of communications

### DIFF
--- a/source/communication/hpx_communicator.cpp
+++ b/source/communication/hpx_communicator.cpp
@@ -3,8 +3,11 @@
 HPX_REGISTER_CHANNEL(array_double);
 
 HPXCommunicator::HPXCommunicator(const DistributedBoundaryMetaData& db_data) {
+    std::vector<hpx::future<void>> channel_futures;
+
     for (auto& rb_meta_data : db_data.rank_boundary_data) {
-        HPXRankBoundary rank_boundary;
+        this->rank_boundaries.emplace_back();
+        HPXRankBoundary& rank_boundary = this->rank_boundaries.back();
 
         rank_boundary.db_data = rb_meta_data;
 
@@ -17,20 +20,19 @@ HPXCommunicator::HPXCommunicator(const DistributedBoundaryMetaData& db_data) {
         std::string outgoing_channel_string = "channel_from_" + my_location + "_to_" + neighbor_location;
         std::string incoming_channel_string = "channel_from_" + neighbor_location + "_to_" + my_location;
 
-        rank_boundary.outgoing                 = hpx::lcos::channel<array_double>(hpx::find_here());
-        hpx::future<void> set_outgoing_channel = rank_boundary.outgoing.register_as(outgoing_channel_string);
+        rank_boundary.outgoing = hpx::lcos::channel<array_double>(hpx::find_here());
+        channel_futures.emplace_back(rank_boundary.outgoing.register_as(outgoing_channel_string));
 
         rank_boundary.incoming.connect_to(incoming_channel_string);
-
-        this->rank_boundaries.push_back(std::move(rank_boundary));
-
-        set_outgoing_channel.get();
     }
+    hpx::when_all(channel_futures).get();
 }
 
 void HPXCommunicator::SendAll(const uint comm_type, const uint timestamp) {
+    const uint offset = this->GetNCommunications()*timestamp + comm_type;
+
     for (auto& rank_boundary : this->rank_boundaries) {
-        rank_boundary.outgoing.set(rank_boundary.send_buffer[comm_type], timestamp);
+        rank_boundary.outgoing.set(rank_boundary.send_buffer[comm_type], offset);
     }
 }
 
@@ -38,8 +40,10 @@ hpx::future<void> HPXCommunicator::ReceiveAll(const uint comm_type, const uint t
     std::vector<hpx::future<void>> receive_futures;
     receive_futures.reserve(this->rank_boundaries.size());
 
+    const uint offset = this->GetNCommunications()*timestamp + comm_type;
+
     for (auto& rank_boundary : this->rank_boundaries) {
-        receive_futures.push_back(rank_boundary.incoming.get(timestamp).then(
+        receive_futures.push_back(rank_boundary.incoming.get(offset).then(
             [&rank_boundary, comm_type](hpx::future<array_double> msg_future) {
                 rank_boundary.receive_buffer[comm_type] = msg_future.get();
             }));

--- a/source/communication/hpx_communicator.cpp
+++ b/source/communication/hpx_communicator.cpp
@@ -29,7 +29,7 @@ HPXCommunicator::HPXCommunicator(const DistributedBoundaryMetaData& db_data) {
 }
 
 void HPXCommunicator::SendAll(const uint comm_type, const uint timestamp) {
-    const uint offset = this->GetNCommunications()*timestamp + comm_type;
+    const uint offset = this->GetNCommunications() * timestamp + comm_type;
 
     for (auto& rank_boundary : this->rank_boundaries) {
         rank_boundary.outgoing.set(rank_boundary.send_buffer[comm_type], offset);
@@ -40,11 +40,11 @@ hpx::future<void> HPXCommunicator::ReceiveAll(const uint comm_type, const uint t
     std::vector<hpx::future<void>> receive_futures;
     receive_futures.reserve(this->rank_boundaries.size());
 
-    const uint offset = this->GetNCommunications()*timestamp + comm_type;
+    const uint offset = this->GetNCommunications() * timestamp + comm_type;
 
     for (auto& rank_boundary : this->rank_boundaries) {
-        receive_futures.push_back(rank_boundary.incoming.get(offset).then(
-            [&rank_boundary, comm_type](hpx::future<array_double> msg_future) {
+        receive_futures.push_back(
+            rank_boundary.incoming.get(offset).then([&rank_boundary, comm_type](hpx::future<array_double> msg_future) {
                 rank_boundary.receive_buffer[comm_type] = msg_future.get();
             }));
     }

--- a/source/communication/hpx_communicator.hpp
+++ b/source/communication/hpx_communicator.hpp
@@ -40,6 +40,7 @@ class HPXCommunicator {
     HPXCommunicator(const DistributedBoundaryMetaData& db_data);
 
     uint GetRankBoundaryNumber() { return this->rank_boundaries.size(); }
+    uint GetNCommunications() { return this->GetRankBoundaryNumber() > 0 ? this->rank_boundaries.front().send_buffer.size() : 0u; }
     HPXRankBoundary& GetRankBoundary(const uint rank_boundary_id) { return this->rank_boundaries.at(rank_boundary_id); }
 
     void SendAll(const uint comm_type, const uint timestamp);

--- a/source/communication/hpx_communicator.hpp
+++ b/source/communication/hpx_communicator.hpp
@@ -40,7 +40,9 @@ class HPXCommunicator {
     HPXCommunicator(const DistributedBoundaryMetaData& db_data);
 
     uint GetRankBoundaryNumber() { return this->rank_boundaries.size(); }
-    uint GetNCommunications() { return this->GetRankBoundaryNumber() > 0 ? this->rank_boundaries.front().send_buffer.size() : 0u; }
+    uint GetNCommunications() {
+        return this->GetRankBoundaryNumber() > 0 ? this->rank_boundaries.front().send_buffer.size() : 0u;
+    }
     HPXRankBoundary& GetRankBoundary(const uint rank_boundary_id) { return this->rank_boundaries.at(rank_boundary_id); }
 
     void SendAll(const uint comm_type, const uint timestamp);


### PR DESCRIPTION
Fixes #116

- adding offset function to improve readability
- removing unnecessary move out of `HPXCommunicator` constructor
- Waiting for all futures at the end of `HPXCommunicator` constructor