### PR TITLE
Modifications to generate vectorized code on Skylake and KNL nodes

### DIFF
--- a/partitioner/problem/swe_partitioner_inputs.cpp
+++ b/partitioner/problem/swe_partitioner_inputs.cpp
@@ -30,7 +30,7 @@ PartitionerInputs::PartitionerInputs(const MeshMetaData& mesh, Inputs inputs) {
             is_wet &= (h_at_vrtx >= inputs.wet_dry.h_o);
         }
 
-        weights.insert(std::make_pair(elt.first, std::vector<double>{1., is_wet}));
+        weights.insert(std::make_pair(elt.first, std::vector<double>{1., (double)is_wet}));
     }
 
     {

--- a/scripts/build/build-yaml-cpp.sh
+++ b/scripts/build/build-yaml-cpp.sh
@@ -172,7 +172,8 @@ if [ ! -d "$YAML_CPP_BUILD_PATH" ]; then
     #
 
     CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-                 -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH}"
+                 -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH}\
+                 -DYAML_CPP_BUILD_TESTS=OFF"
     if [ -v CXX_COMPILER ]; then
     CMAKE_FLAGS="$CMAKE_FLAGS \
                  -DCMAKE_CXX_COMPILER=${CXX_COMPILER}"

--- a/scripts/build/config.txt
+++ b/scripts/build/config.txt
@@ -13,7 +13,7 @@ fi
 
 if [ "$MACHINE" == "stampede2-knl" ] || [ "$MACHINE" == "stampede2-skx" ]; then
     NUM_BUILDCORES=16
-    MODULES="xalt/1.7 TACC gcc/7.1.0 boost/1.64 cmake/3.8.2"
+    MODULES="xalt/2.1.2 TACC gcc/7.1.0 boost/1.64 cmake/3.8.2"
     CMAKE="cmake"
 
 #    VTUNE_MODULES="vtune/17.update4"

--- a/scripts/build/config.txt
+++ b/scripts/build/config.txt
@@ -13,7 +13,7 @@ fi
 
 if [ "$MACHINE" == "stampede2-knl" ] || [ "$MACHINE" == "stampede2-skx" ]; then
     NUM_BUILDCORES=16
-    MODULES="xalt/2.1.2 TACC gcc/7.1.0 boost/1.64 cmake/3.8.2"
+    MODULES="xalt/2.1.2 TACC gcc/7.1.0 boost/1.64 cmake/3.8.2 mkl/17.0.4"
     CMAKE="cmake"
 
 #    VTUNE_MODULES="vtune/17.update4"

--- a/source/general_definitions.hpp
+++ b/source/general_definitions.hpp
@@ -23,13 +23,14 @@
 #include <tuple>
 #include <stdlib.h>
 #include <time.h>
-#include "utilities/linear_algebra.hpp"
-
-#include "edge_types.hpp"
 
 #ifdef HAS_HPX
 #include "simulation/hpx/load_balancer/serialization_headers.hpp"
 #endif
+#include "utilities/linear_algebra.hpp"
+
+#include "edge_types.hpp"
+
 
 using uchar = unsigned char;
 

--- a/source/general_definitions.hpp
+++ b/source/general_definitions.hpp
@@ -31,7 +31,6 @@
 
 #include "edge_types.hpp"
 
-
 using uchar = unsigned char;
 
 using uint = unsigned int;
@@ -197,10 +196,12 @@ class Shape {
     virtual DynVector<double> GetJdet(const std::vector<Point<dimension>>& points)                          = 0;
     virtual DynVector<double> GetSurfaceJ(const uint bound_id, const std::vector<Point<dimension>>& points) = 0;
 
-    virtual AlignedVector<StatMatrix<double, dimension, dimension>> GetJinv(const std::vector<Point<dimension>>& points) = 0;
+    virtual AlignedVector<StatMatrix<double, dimension, dimension>> GetJinv(
+        const std::vector<Point<dimension>>& points) = 0;
 
-    virtual AlignedVector<StatVector<double, dimension>> GetSurfaceNormal( const uint bound_id,
-    					       				   const std::vector<Point<dimension>>& points) = 0;
+    virtual AlignedVector<StatVector<double, dimension>> GetSurfaceNormal(
+        const uint bound_id,
+        const std::vector<Point<dimension>>& points) = 0;
 
     virtual DynMatrix<double> GetPsi(const std::vector<Point<dimension>>& points)                         = 0;
     virtual std::array<DynMatrix<double>, dimension> GetDPsi(const std::vector<Point<dimension>>& points) = 0;

--- a/source/general_definitions.hpp
+++ b/source/general_definitions.hpp
@@ -206,11 +206,15 @@ class Shape {
 
     virtual DynVector<double> GetJdet(const std::vector<Point<dimension>>& points)                          = 0;
     virtual DynVector<double> GetSurfaceJ(const uint bound_id, const std::vector<Point<dimension>>& points) = 0;
-    virtual std::vector<StatMatrix<double, dimension, dimension>> GetJinv(
-        const std::vector<Point<dimension>>& points) = 0;
-    virtual std::vector<StatVector<double, dimension>> GetSurfaceNormal(
-        const uint bound_id,
-        const std::vector<Point<dimension>>& points) = 0;
+
+    virtual std::vector<StatMatrix<double, dimension, dimension>,
+			AlignedAllocator<StatMatrix<double, dimension, dimension>>
+			> GetJinv(const std::vector<Point<dimension>>& points) = 0;
+
+    virtual std::vector<StatVector<double, dimension>,
+			AlignedAllocator<StatVector<double,dimension>>
+			> GetSurfaceNormal( const uint bound_id,
+					    const std::vector<Point<dimension>>& points) = 0;
 
     virtual DynMatrix<double> GetPsi(const std::vector<Point<dimension>>& points)                         = 0;
     virtual std::array<DynMatrix<double>, dimension> GetDPsi(const std::vector<Point<dimension>>& points) = 0;

--- a/source/general_definitions.hpp
+++ b/source/general_definitions.hpp
@@ -23,6 +23,7 @@
 #include <tuple>
 #include <stdlib.h>
 #include <time.h>
+#include "utilities/linear_algebra.hpp"
 
 #include "edge_types.hpp"
 
@@ -33,18 +34,6 @@
 using uchar = unsigned char;
 
 using uint = unsigned int;
-
-/* This will have to go into linear_algebra.hpp */
-#define USE_EIGEN
-//#define USE_BLAZE
-
-#ifdef USE_BLAZE
-#include "utilities/linear_algebra/use_blaze.hpp"
-#endif
-
-#ifdef USE_EIGEN
-#include "utilities/linear_algebra/use_eigen.hpp"
-#endif
 
 template <uint dimension>
 using Point = std::array<double, dimension>;
@@ -207,14 +196,10 @@ class Shape {
     virtual DynVector<double> GetJdet(const std::vector<Point<dimension>>& points)                          = 0;
     virtual DynVector<double> GetSurfaceJ(const uint bound_id, const std::vector<Point<dimension>>& points) = 0;
 
-    virtual std::vector<StatMatrix<double, dimension, dimension>,
-			AlignedAllocator<StatMatrix<double, dimension, dimension>>
-			> GetJinv(const std::vector<Point<dimension>>& points) = 0;
+    virtual AlignedVector<StatMatrix<double, dimension, dimension>> GetJinv(const std::vector<Point<dimension>>& points) = 0;
 
-    virtual std::vector<StatVector<double, dimension>,
-			AlignedAllocator<StatVector<double,dimension>>
-			> GetSurfaceNormal( const uint bound_id,
-					    const std::vector<Point<dimension>>& points) = 0;
+    virtual AlignedVector<StatVector<double, dimension>> GetSurfaceNormal( const uint bound_id,
+    					       				   const std::vector<Point<dimension>>& points) = 0;
 
     virtual DynMatrix<double> GetPsi(const std::vector<Point<dimension>>& points)                         = 0;
     virtual std::array<DynMatrix<double>, dimension> GetDPsi(const std::vector<Point<dimension>>& points) = 0;

--- a/source/geometry/element.hpp
+++ b/source/geometry/element.hpp
@@ -111,9 +111,9 @@ class Element {
 
     void InitializeVTK(std::vector<Point<3>>& points, Array2D<uint>& cells);
     template <typename InputArrayType, typename OutputArrayType>
-    void WriteCellDataVTK(const InputArrayType& u, std::vector<OutputArrayType>& cell_data);
+    void WriteCellDataVTK(const InputArrayType& u, AlignedVector<OutputArrayType>& cell_data);
     template <typename InputArrayType, typename OutputArrayType>
-    void WritePointDataVTK(const InputArrayType& u, std::vector<OutputArrayType>& point_data);
+    void WritePointDataVTK(const InputArrayType& u, AlignedVector<OutputArrayType>& point_data);
 
     template <typename F, typename InputArrayType>
     double ComputeResidualL2(const F& f, const InputArrayType& u);
@@ -159,10 +159,8 @@ void Element<dimension, MasterType, ShapeType, DataType>::Initialize() {
 
     // DEFORMATION
     DynVector<double> det_J = this->shape.GetJdet(this->master->integration_rule.second);
-    std::vector<StatMatrix<double, dimension, dimension>,
-		AlignedAllocator<StatMatrix<double, dimension, dimension>>
-		> J_inv =
-      this->shape.GetJinv(this->master->integration_rule.second);
+    AlignedVector<StatMatrix<double, dimension, dimension>> J_inv =
+        this->shape.GetJinv(this->master->integration_rule.second);
 
     this->const_J = (det_J.size() == 1);
 
@@ -487,7 +485,7 @@ template <uint dimension, typename MasterType, typename ShapeType, typename Data
 template <typename InputArrayType, typename OutputArrayType>
 inline void Element<dimension, MasterType, ShapeType, DataType>::WriteCellDataVTK(
     const InputArrayType& u,
-    std::vector<OutputArrayType>& cell_data) {
+    AlignedVector<OutputArrayType>& cell_data) {
     // cell_data[q] = u(q, dof) * phi_postprocessor_cell(dof, cell)
     OutputArrayType temp;
 
@@ -502,7 +500,7 @@ template <uint dimension, typename MasterType, typename ShapeType, typename Data
 template <typename InputArrayType, typename OutputArrayType>
 inline void Element<dimension, MasterType, ShapeType, DataType>::WritePointDataVTK(
     const InputArrayType& u,
-    std::vector<OutputArrayType>& point_data) {
+    AlignedVector<OutputArrayType>& point_data) {
     // point_data[q] = u(q, dof) * phi_postprocessor_point(pt, dof)
     OutputArrayType temp;
 

--- a/source/geometry/element.hpp
+++ b/source/geometry/element.hpp
@@ -159,8 +159,10 @@ void Element<dimension, MasterType, ShapeType, DataType>::Initialize() {
 
     // DEFORMATION
     DynVector<double> det_J = this->shape.GetJdet(this->master->integration_rule.second);
-    std::vector<StatMatrix<double, dimension, dimension>> J_inv =
-        this->shape.GetJinv(this->master->integration_rule.second);
+    std::vector<StatMatrix<double, dimension, dimension>,
+		AlignedAllocator<StatMatrix<double, dimension, dimension>>
+		> J_inv =
+      this->shape.GetJinv(this->master->integration_rule.second);
 
     this->const_J = (det_J.size() == 1);
 

--- a/source/geometry/mesh.hpp
+++ b/source/geometry/mesh.hpp
@@ -41,6 +41,10 @@ class Mesh<std::tuple<Elements...>,
   public:
     Mesh() = default;
     Mesh(const uint p) : p(p), masters(master_maker<MasterElementTypes>::construct_masters(p)) {}
+    Mesh& operator=(const Mesh&) = delete;
+    Mesh(Mesh&) = delete;
+    Mesh& operator=(Mesh&&) =default;
+    Mesh(Mesh&&) = default;
 
     std::string GetMeshName() { return this->mesh_name; }
     void SetMeshName(const std::string& mesh_name) { this->mesh_name = mesh_name; }

--- a/source/problem/SWE/discretization_EHDG/kernels_postprocessor/ehdg_swe_post_write_vtk.hpp
+++ b/source/problem/SWE/discretization_EHDG/kernels_postprocessor/ehdg_swe_post_write_vtk.hpp
@@ -7,11 +7,11 @@ namespace SWE {
 namespace EHDG {
 template <typename MeshType>
 void Problem::write_VTK_data(MeshType& mesh, std::ofstream& raw_data_file) {
-    std::vector<StatVector<double, SWE::n_variables>> q_point_data;
-    std::vector<StatVector<double, SWE::n_variables>> q_cell_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_point_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_cell_data;
 
-    std::vector<StatVector<double, 1>> aux_point_data;
-    std::vector<StatVector<double, 1>> aux_cell_data;
+    AlignedVector<StatVector<double, 1>> aux_point_data;
+    AlignedVector<StatVector<double, 1>> aux_cell_data;
 
     mesh.CallForEachElement([&q_point_data, &q_cell_data, &aux_point_data, &aux_cell_data](auto& elt) {
         elt.WritePointDataVTK(elt.data.state[0].q, q_point_data);

--- a/source/problem/SWE/discretization_EHDG/kernels_postprocessor/ehdg_swe_post_write_vtu.hpp
+++ b/source/problem/SWE/discretization_EHDG/kernels_postprocessor/ehdg_swe_post_write_vtu.hpp
@@ -7,11 +7,11 @@ namespace SWE {
 namespace EHDG {
 template <typename MeshType>
 void Problem::write_VTU_data(MeshType& mesh, std::ofstream& raw_data_file) {
-    std::vector<StatVector<double, SWE::n_variables>> q_point_data;
-    std::vector<StatVector<double, SWE::n_variables>> q_cell_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_point_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_cell_data;
 
-    std::vector<StatVector<double, 1>> aux_point_data;
-    std::vector<StatVector<double, 1>> aux_cell_data;
+    AlignedVector<StatVector<double, 1>> aux_point_data;
+    AlignedVector<StatVector<double, 1>> aux_cell_data;
 
     mesh.CallForEachElement([&q_point_data, &q_cell_data, &aux_point_data, &aux_cell_data](auto& elt) {
         elt.WritePointDataVTK(elt.data.state[0].q, q_point_data);

--- a/source/problem/SWE/discretization_IHDG/kernels_postprocessor/ihdg_swe_post_write_vtk.hpp
+++ b/source/problem/SWE/discretization_IHDG/kernels_postprocessor/ihdg_swe_post_write_vtk.hpp
@@ -6,11 +6,11 @@
 namespace SWE {
 namespace IHDG {
 void Problem::write_VTK_data(ProblemMeshType& mesh, std::ofstream& raw_data_file) {
-    std::vector<StatVector<double, SWE::n_variables>> q_point_data;
-    std::vector<StatVector<double, SWE::n_variables>> q_cell_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_point_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_cell_data;
 
-    std::vector<StatVector<double, 1>> aux_point_data;
-    std::vector<StatVector<double, 1>> aux_cell_data;
+    AlignedVector<StatVector<double, 1>> aux_point_data;
+    AlignedVector<StatVector<double, 1>> aux_cell_data;
 
     mesh.CallForEachElement([&q_point_data, &q_cell_data, &aux_point_data, &aux_cell_data](auto& elt) {
         elt.WritePointDataVTK(elt.data.state[0].q, q_point_data);

--- a/source/problem/SWE/discretization_IHDG/kernels_postprocessor/ihdg_swe_post_write_vtu.hpp
+++ b/source/problem/SWE/discretization_IHDG/kernels_postprocessor/ihdg_swe_post_write_vtu.hpp
@@ -6,11 +6,11 @@
 namespace SWE {
 namespace IHDG {
 void Problem::write_VTU_data(ProblemMeshType& mesh, std::ofstream& raw_data_file) {
-    std::vector<StatVector<double, SWE::n_variables>> q_point_data;
-    std::vector<StatVector<double, SWE::n_variables>> q_cell_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_point_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_cell_data;
 
-    std::vector<StatVector<double, 1>> aux_point_data;
-    std::vector<StatVector<double, 1>> aux_cell_data;
+    AlignedVector<StatVector<double, 1>> aux_point_data;
+    AlignedVector<StatVector<double, 1>> aux_cell_data;
 
     mesh.CallForEachElement([&q_point_data, &q_cell_data, &aux_point_data, &aux_cell_data](auto& elt) {
         elt.WritePointDataVTK(elt.data.state[0].q, q_point_data);

--- a/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data.hpp
+++ b/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data.hpp
@@ -13,16 +13,16 @@
 namespace SWE {
 namespace RKDG {
 struct Data {
-    std::vector<State> state;
+    std::vector<State,AlignedAllocator<State>> state;
     Internal internal;
-    std::vector<Boundary> boundary;
+    std::vector<Boundary,AlignedAllocator<Boundary>> boundary;
 
     Source source;
     WetDry wet_dry_state;
     SlopeLimit slope_limit_state;
 
     void initialize() {
-        this->state = std::vector<State>{State(this->ndof)};
+        this->state.emplace_back(this->ndof);
 
         this->internal = Internal(this->ngp_internal);
 

--- a/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data.hpp
+++ b/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data.hpp
@@ -13,9 +13,9 @@
 namespace SWE {
 namespace RKDG {
 struct Data {
-    std::vector<State,AlignedAllocator<State>> state;
+    AlignedVector<State> state;
     Internal internal;
-    std::vector<Boundary,AlignedAllocator<Boundary>> boundary;
+    AlignedVector<Boundary> boundary;
 
     Source source;
     WetDry wet_dry_state;

--- a/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_slope_limit.hpp
+++ b/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_slope_limit.hpp
@@ -22,8 +22,7 @@ struct SlopeLimit {
           wet_neigh(nbound),
           q_at_baryctr_neigh(nbound) {}
 
-    std::vector<StatVector<double, SWE::n_dimensions>,
-                AlignedAllocator<StatVector<double, SWE::n_dimensions>>> surface_normal;
+    AlignedVector<StatVector<double, SWE::n_dimensions>> surface_normal;
 
     Point<2> baryctr_coord;
     std::vector<Point<2>> midpts_coord;
@@ -44,8 +43,7 @@ struct SlopeLimit {
     DynRowVector<double> bath_at_midpts;
 
     std::vector<bool> wet_neigh;
-    std::vector<StatVector<double, SWE::n_variables>,
-                AlignedAllocator<StatVector<double, SWE::n_variables>>> q_at_baryctr_neigh;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_at_baryctr_neigh;
 
     StatMatrix<double, SWE::n_variables, SWE::n_variables> L;
     StatMatrix<double, SWE::n_variables, SWE::n_variables> R;

--- a/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_slope_limit.hpp
+++ b/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_slope_limit.hpp
@@ -22,7 +22,8 @@ struct SlopeLimit {
           wet_neigh(nbound),
           q_at_baryctr_neigh(nbound) {}
 
-    std::vector<StatVector<double, SWE::n_dimensions>> surface_normal;
+    std::vector<StatVector<double, SWE::n_dimensions>,
+                AlignedAllocator<StatVector<double, SWE::n_dimensions>>> surface_normal;
 
     Point<2> baryctr_coord;
     std::vector<Point<2>> midpts_coord;
@@ -43,7 +44,8 @@ struct SlopeLimit {
     DynRowVector<double> bath_at_midpts;
 
     std::vector<bool> wet_neigh;
-    std::vector<StatVector<double, SWE::n_variables>> q_at_baryctr_neigh;
+    std::vector<StatVector<double, SWE::n_variables>,
+                AlignedAllocator<StatVector<double, SWE::n_variables>>> q_at_baryctr_neigh;
 
     StatMatrix<double, SWE::n_variables, SWE::n_variables> L;
     StatMatrix<double, SWE::n_variables, SWE::n_variables> R;

--- a/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_source.hpp
+++ b/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data_source.hpp
@@ -17,7 +17,7 @@ struct Source {
 
     std::vector<std::vector<double>*> parsed_meteo_data;
 
-    std::vector<StatVector<double, SWE::n_dimensions>> tau_s;
+    AlignedVector<StatVector<double, SWE::n_dimensions>> tau_s;
     std::vector<double> p_atm;
 
     std::vector<double> tide_pot;

--- a/source/problem/SWE/discretization_RKDG/kernels_postprocessor/rkdg_swe_post_write_vtk.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_postprocessor/rkdg_swe_post_write_vtk.hpp
@@ -6,11 +6,11 @@
 namespace SWE {
 namespace RKDG {
 void Problem::write_VTK_data(ProblemMeshType& mesh, std::ofstream& raw_data_file) {
-    std::vector<StatVector<double, SWE::n_variables>> q_point_data;
-    std::vector<StatVector<double, SWE::n_variables>> q_cell_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_point_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_cell_data;
 
-    std::vector<StatVector<double, 1>> aux_point_data;
-    std::vector<StatVector<double, 1>> aux_cell_data;
+    AlignedVector<StatVector<double, 1>> aux_point_data;
+    AlignedVector<StatVector<double, 1>> aux_cell_data;
 
     mesh.CallForEachElement([&q_point_data, &q_cell_data, &aux_point_data, &aux_cell_data](auto& elt) {
         elt.WritePointDataVTK(elt.data.state[0].q, q_point_data);

--- a/source/problem/SWE/discretization_RKDG/kernels_postprocessor/rkdg_swe_post_write_vtu.hpp
+++ b/source/problem/SWE/discretization_RKDG/kernels_postprocessor/rkdg_swe_post_write_vtu.hpp
@@ -6,11 +6,11 @@
 namespace SWE {
 namespace RKDG {
 void Problem::write_VTU_data(ProblemMeshType& mesh, std::ofstream& raw_data_file) {
-    std::vector<StatVector<double, SWE::n_variables>> q_point_data;
-    std::vector<StatVector<double, SWE::n_variables>> q_cell_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_point_data;
+    AlignedVector<StatVector<double, SWE::n_variables>> q_cell_data;
 
-    std::vector<StatVector<double, 1>> aux_point_data;
-    std::vector<StatVector<double, 1>> aux_cell_data;
+    AlignedVector<StatVector<double, 1>> aux_point_data;
+    AlignedVector<StatVector<double, 1>> aux_cell_data;
 
     mesh.CallForEachElement([&q_point_data, &q_cell_data, &aux_point_data, &aux_cell_data](auto& elt) {
         elt.WritePointDataVTK(elt.data.state[0].q, q_point_data);

--- a/source/shape/shapes_2D.hpp
+++ b/source/shape/shapes_2D.hpp
@@ -16,8 +16,15 @@ class StraightTriangle : public Shape<2> {
 
     DynVector<double> GetJdet(const std::vector<Point<2>>& points);
     DynVector<double> GetSurfaceJ(const uint bound_id, const std::vector<Point<2>>& points);
-    std::vector<StatMatrix<double, 2, 2>> GetJinv(const std::vector<Point<2>>& points);
-    std::vector<StatVector<double, 2>> GetSurfaceNormal(const uint bound_id, const std::vector<Point<2>>& points);
+
+    std::vector<StatMatrix<double, 2, 2>,
+		AlignedAllocator<StatMatrix<double, 2, 2>>
+		> GetJinv(const std::vector<Point<2>>& points);
+
+    std::vector<StatVector<double, 2>,
+		AlignedAllocator<StatVector<double,2>>
+		> GetSurfaceNormal( const uint bound_id,
+				    const std::vector<Point<2>>& points);
 
     DynMatrix<double> GetPsi(const std::vector<Point<2>>& points);
     std::array<DynMatrix<double>, 2> GetDPsi(const std::vector<Point<2>>& points);

--- a/source/shape/shapes_2D.hpp
+++ b/source/shape/shapes_2D.hpp
@@ -19,8 +19,7 @@ class StraightTriangle : public Shape<2> {
 
     AlignedVector<StatMatrix<double, 2, 2>> GetJinv(const std::vector<Point<2>>& points);
 
-    AlignedVector<StatVector<double, 2>> GetSurfaceNormal( const uint bound_id,
-							   const std::vector<Point<2>>& points);
+    AlignedVector<StatVector<double, 2>> GetSurfaceNormal(const uint bound_id, const std::vector<Point<2>>& points);
 
     DynMatrix<double> GetPsi(const std::vector<Point<2>>& points);
     std::array<DynMatrix<double>, 2> GetDPsi(const std::vector<Point<2>>& points);

--- a/source/shape/shapes_2D.hpp
+++ b/source/shape/shapes_2D.hpp
@@ -17,14 +17,10 @@ class StraightTriangle : public Shape<2> {
     DynVector<double> GetJdet(const std::vector<Point<2>>& points);
     DynVector<double> GetSurfaceJ(const uint bound_id, const std::vector<Point<2>>& points);
 
-    std::vector<StatMatrix<double, 2, 2>,
-		AlignedAllocator<StatMatrix<double, 2, 2>>
-		> GetJinv(const std::vector<Point<2>>& points);
+    AlignedVector<StatMatrix<double, 2, 2>> GetJinv(const std::vector<Point<2>>& points);
 
-    std::vector<StatVector<double, 2>,
-		AlignedAllocator<StatVector<double,2>>
-		> GetSurfaceNormal( const uint bound_id,
-				    const std::vector<Point<2>>& points);
+    AlignedVector<StatVector<double, 2>> GetSurfaceNormal( const uint bound_id,
+							   const std::vector<Point<2>>& points);
 
     DynMatrix<double> GetPsi(const std::vector<Point<2>>& points);
     std::array<DynMatrix<double>, 2> GetDPsi(const std::vector<Point<2>>& points);

--- a/source/shape/shapes_2D/shape_straighttriangle.cpp
+++ b/source/shape/shapes_2D/shape_straighttriangle.cpp
@@ -80,8 +80,10 @@ DynVector<double> StraightTriangle::GetSurfaceJ(const uint bound_id, const std::
     return surface_J;
 }
 
-std::vector<StatMatrix<double, 2, 2>> StraightTriangle::GetJinv(const std::vector<Point<2>>& points) {
-    std::vector<StatMatrix<double, 2, 2>> J_inv(1);
+std::vector<StatMatrix<double, 2, 2>,
+	    AlignedAllocator<StatMatrix<double, 2, 2>>
+	    >  StraightTriangle::GetJinv(const std::vector<Point<2>>& points) {
+    std::vector<StatMatrix<double, 2, 2>,AlignedAllocator<StatMatrix<double, 2, 2>>> J_inv(1);
 
     StatMatrix<double, 2, 2> J;
 
@@ -95,9 +97,13 @@ std::vector<StatMatrix<double, 2, 2>> StraightTriangle::GetJinv(const std::vecto
     return J_inv;
 }
 
-std::vector<StatVector<double, 2>> StraightTriangle::GetSurfaceNormal(const uint bound_id,
-                                                                      const std::vector<Point<2>>& points) {
-    std::vector<StatVector<double, 2>> surface_normal(1);
+std::vector<StatVector<double, 2>,
+	    AlignedAllocator<StatVector<double,2>>
+	    > StraightTriangle::GetSurfaceNormal(const uint bound_id,
+						 const std::vector<Point<2>>& points) {
+  std::vector<StatVector<double, 2>,
+	      AlignedAllocator<StatVector<double,2>>
+	      > surface_normal(1);
 
     StatMatrix<double, 2, 2> J;
 
@@ -109,12 +115,10 @@ std::vector<StatVector<double, 2>> StraightTriangle::GetSurfaceNormal(const uint
     double det_J = determinant(J);
     double cw    = det_J / std::abs(det_J);  // CW or CCW
 
-    double length = sqrt(pow(this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::x] -
-                                 this->nodal_coordinates[(bound_id + 1) % 3][GlobalCoord::x],
-                             2.0) +
-                         pow(this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::y] -
-                                 this->nodal_coordinates[(bound_id + 1) % 3][GlobalCoord::y],
-                             2.0));
+    double length = std::hypot(this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::x] -
+			       this->nodal_coordinates[(bound_id + 1) % 3][GlobalCoord::x],
+			       this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::y] -
+			       this->nodal_coordinates[(bound_id + 1) % 3][GlobalCoord::y]);
 
     surface_normal[0][GlobalCoord::x] = cw *
                                         (this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::y] -

--- a/source/shape/shapes_2D/shape_straighttriangle.cpp
+++ b/source/shape/shapes_2D/shape_straighttriangle.cpp
@@ -80,10 +80,8 @@ DynVector<double> StraightTriangle::GetSurfaceJ(const uint bound_id, const std::
     return surface_J;
 }
 
-std::vector<StatMatrix<double, 2, 2>,
-	    AlignedAllocator<StatMatrix<double, 2, 2>>
-	    >  StraightTriangle::GetJinv(const std::vector<Point<2>>& points) {
-    std::vector<StatMatrix<double, 2, 2>,AlignedAllocator<StatMatrix<double, 2, 2>>> J_inv(1);
+AlignedVector<StatMatrix<double, 2, 2>>  StraightTriangle::GetJinv(const std::vector<Point<2>>& points) {
+    AlignedVector<StatMatrix<double, 2, 2>> J_inv(1);
 
     StatMatrix<double, 2, 2> J;
 
@@ -97,13 +95,9 @@ std::vector<StatMatrix<double, 2, 2>,
     return J_inv;
 }
 
-std::vector<StatVector<double, 2>,
-	    AlignedAllocator<StatVector<double,2>>
-	    > StraightTriangle::GetSurfaceNormal(const uint bound_id,
-						 const std::vector<Point<2>>& points) {
-  std::vector<StatVector<double, 2>,
-	      AlignedAllocator<StatVector<double,2>>
-	      > surface_normal(1);
+AlignedVector<StatVector<double, 2>> StraightTriangle::GetSurfaceNormal(const uint bound_id,
+									const std::vector<Point<2>>& points) {
+    AlignedVector<StatVector<double, 2>> surface_normal(1);
 
     StatMatrix<double, 2, 2> J;
 

--- a/source/shape/shapes_2D/shape_straighttriangle.cpp
+++ b/source/shape/shapes_2D/shape_straighttriangle.cpp
@@ -80,7 +80,7 @@ DynVector<double> StraightTriangle::GetSurfaceJ(const uint bound_id, const std::
     return surface_J;
 }
 
-AlignedVector<StatMatrix<double, 2, 2>>  StraightTriangle::GetJinv(const std::vector<Point<2>>& points) {
+AlignedVector<StatMatrix<double, 2, 2>> StraightTriangle::GetJinv(const std::vector<Point<2>>& points) {
     AlignedVector<StatMatrix<double, 2, 2>> J_inv(1);
 
     StatMatrix<double, 2, 2> J;
@@ -96,7 +96,7 @@ AlignedVector<StatMatrix<double, 2, 2>>  StraightTriangle::GetJinv(const std::ve
 }
 
 AlignedVector<StatVector<double, 2>> StraightTriangle::GetSurfaceNormal(const uint bound_id,
-									const std::vector<Point<2>>& points) {
+                                                                        const std::vector<Point<2>>& points) {
     AlignedVector<StatVector<double, 2>> surface_normal(1);
 
     StatMatrix<double, 2, 2> J;
@@ -110,9 +110,9 @@ AlignedVector<StatVector<double, 2>> StraightTriangle::GetSurfaceNormal(const ui
     double cw    = det_J / std::abs(det_J);  // CW or CCW
 
     double length = std::hypot(this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::x] -
-			       this->nodal_coordinates[(bound_id + 1) % 3][GlobalCoord::x],
-			       this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::y] -
-			       this->nodal_coordinates[(bound_id + 1) % 3][GlobalCoord::y]);
+                                   this->nodal_coordinates[(bound_id + 1) % 3][GlobalCoord::x],
+                               this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::y] -
+                                   this->nodal_coordinates[(bound_id + 1) % 3][GlobalCoord::y]);
 
     surface_normal[0][GlobalCoord::x] = cw *
                                         (this->nodal_coordinates[(bound_id + 2) % 3][GlobalCoord::y] -

--- a/source/utilities/almost_equal.hpp
+++ b/source/utilities/almost_equal.hpp
@@ -21,7 +21,7 @@ constexpr bool almost_equal(double a, double b, double factor = 100) {
     }
 
     return std::abs(a - b) < (std::max(std::abs(a), std::abs(b)) * std::numeric_limits<double>::epsilon() * factor);
-};
+}
 }
 
 #endif

--- a/source/utilities/heterogeneous_containers.hpp
+++ b/source/utilities/heterogeneous_containers.hpp
@@ -16,7 +16,7 @@ namespace Utilities {
 template <typename... Ts>
 struct HeterogeneousVector {
     using TupleType = std::tuple<Ts...>;
-    std::tuple<std::vector<Ts,AlignedAllocator<Ts>>...> data;
+    std::tuple<AlignedVector<Ts>...> data;
 
     /**
      * Returns the total number of elements in the HeterogeneousVector
@@ -75,9 +75,7 @@ struct HeterogeneousVector {
 template <typename... Ts>
 struct HeterogeneousMap {
     using TupleType = std::tuple<Ts...>;
-    std::tuple<
-        std::map<uint, Ts, std::less<uint>, AlignedAllocator<std::pair<const uint, Ts>>>...
-    > data;
+    std::tuple<AlignedMap<uint, Ts>...> data;
 
     /**
      * Returns the total number of elements in the HeterogeneousMap

--- a/source/utilities/heterogeneous_containers.hpp
+++ b/source/utilities/heterogeneous_containers.hpp
@@ -16,7 +16,7 @@ namespace Utilities {
 template <typename... Ts>
 struct HeterogeneousVector {
     using TupleType = std::tuple<Ts...>;
-    std::tuple<std::vector<Ts>...> data;
+    std::tuple<std::vector<Ts,AlignedAllocator<Ts>>...> data;
 
     /**
      * Returns the total number of elements in the HeterogeneousVector
@@ -75,7 +75,9 @@ struct HeterogeneousVector {
 template <typename... Ts>
 struct HeterogeneousMap {
     using TupleType = std::tuple<Ts...>;
-    std::tuple<std::map<uint, Ts>...> data;
+    std::tuple<
+        std::map<uint, Ts, std::less<uint>, AlignedAllocator<std::pair<const uint, Ts>>>...
+    > data;
 
     /**
      * Returns the total number of elements in the HeterogeneousMap

--- a/source/utilities/linear_algebra.hpp
+++ b/source/utilities/linear_algebra.hpp
@@ -12,14 +12,13 @@
 #include "utilities/linear_algebra/use_eigen.hpp"
 #endif
 
+// The following are STL containers with aligned allocators.
+// These should be used whenever the template parameter is
+// a static or Hybrid vector type or contains is a class
+// which contains Hybrid or static vector types
+template <typename T>
+using AlignedVector = std::vector<T, AlignedAllocator<T>>;
 
-//The following are STL containers with aligned allocators.
-//These should be used whenever the template parameter is
-//a static or Hybrid vector type or contains is a class
-//which contains Hybrid or static vector types
-template<typename T>
-using AlignedVector = std::vector<T,AlignedAllocator<T>>;
-
-template<typename Key, typename T, typename Compare = std::less<Key> >
-using AlignedMap = std::map<Key,T,Compare,AlignedAllocator<std::pair<Key,T>>>;
+template <typename Key, typename T, typename Compare = std::less<Key>>
+using AlignedMap = std::map<Key, T, Compare, AlignedAllocator<std::pair<Key, T>>>;
 #endif

--- a/source/utilities/linear_algebra.hpp
+++ b/source/utilities/linear_algebra.hpp
@@ -1,0 +1,25 @@
+#ifndef LINEAR_ALGEBRA_HPP
+#define LINEAR_ALGEBRA_HPP
+
+//#define USE_EIGEN
+#define USE_BLAZE
+
+#ifdef USE_BLAZE
+#include "utilities/linear_algebra/use_blaze.hpp"
+#endif
+
+#ifdef USE_EIGEN
+#include "utilities/linear_algebra/use_eigen.hpp"
+#endif
+
+
+//The following are STL containers with aligned allocators.
+//These should be used whenever the template parameter is
+//a static or Hybrid vector type or contains is a class
+//which contains Hybrid or static vector types
+template<typename T>
+using AlignedVector = std::vector<T,AlignedAllocator<T>>;
+
+template<typename Key, typename T, typename Compare = std::less<Key> >
+using AlignedMap = std::map<Key,T,Compare,AlignedAllocator<std::pair<Key,T>>>;
+#endif

--- a/source/utilities/linear_algebra.hpp
+++ b/source/utilities/linear_algebra.hpp
@@ -1,8 +1,8 @@
 #ifndef LINEAR_ALGEBRA_HPP
 #define LINEAR_ALGEBRA_HPP
 
-//#define USE_EIGEN
-#define USE_BLAZE
+#define USE_EIGEN
+//#define USE_BLAZE
 
 #ifdef USE_BLAZE
 #include "utilities/linear_algebra/use_blaze.hpp"

--- a/source/utilities/linear_algebra/use_blaze.hpp
+++ b/source/utilities/linear_algebra/use_blaze.hpp
@@ -6,6 +6,7 @@
 #include <blaze/math/Submatrix.h>
 #include <blaze/math/Column.h>
 #include <blaze/math/Row.h>
+#include <blaze/util/AlignedAllocator.h>
 
 #ifdef HAS_HPX
 #include "serialization/blaze_vector.hpp"
@@ -43,6 +44,9 @@ using SparseMatrix = blaze::CompressedMatrix<T>;
 
 template <typename T>
 using IdentityMatrix = blaze::IdentityMatrix<T>;
+
+template <typename BlazeType>
+using AlignedAllocator = blaze::AlignedAllocator<BlazeType>;
 
 template <typename T>
 DynVector<T> IdentityVector(const uint size) {

--- a/source/utilities/linear_algebra/use_eigen.hpp
+++ b/source/utilities/linear_algebra/use_eigen.hpp
@@ -3,6 +3,7 @@
 
 #include <eigen3/Eigen/Dense>
 #include <eigen3/Eigen/Sparse>
+#include <eigen3/Eigen/StdVector>
 
 #define EIGEN_DONT_PARALLELIZE
 
@@ -36,6 +37,9 @@ template <typename T>
 using SparseVector = Eigen::SparseVector<T>;
 template <typename T>
 using SparseMatrix = Eigen::SparseMatrix<T>;
+
+template <typename EigenType>
+using AlignedAllocator = Eigen::aligned_allocator<EigenType>;
 
 template <typename T>
 DynMatrix<T> IdentityMatrix(const uint size) {

--- a/test/test_boundary_interface.cpp
+++ b/test/test_boundary_interface.cpp
@@ -43,7 +43,7 @@ int main() {
     // generate boundaries
     triangle.CreateRawBoundaries(raw_boundary);
 
-    std::vector<BoundaryType> boundaries;
+    AlignedVector<BoundaryType> boundaries;
 
     for (auto& rb : raw_boundary[SWE::BoundaryTypes::land]) {
         boundaries.emplace_back(BoundaryType(std::move(rb.second)));
@@ -233,7 +233,7 @@ int main() {
     }
 
     // generate Interfaces
-    std::vector<InterfaceType> interfaces;
+    AlignedVector<InterfaceType> interfaces;
 
     for (auto& rb : raw_boundary[SWE::BoundaryTypes::land]) {
         interfaces.emplace_back(InterfaceType(std::move(rb.second), std::move(rb.second)));

--- a/test/test_edges.cpp
+++ b/test/test_edges.cpp
@@ -72,13 +72,13 @@ int main() {
     DynMatrix<double> u_proj_gp(1, integration.GetNumGP(21));  // ngp for 2*p+1
 
     // generate edge boundaries
-    std::vector<BoundaryType> boundaries;
+    AlignedVector<BoundaryType> boundaries;
 
     for (auto& rb : raw_boundary[SWE::BoundaryTypes::land]) {
         boundaries.emplace_back(BoundaryType(std::move(rb.second)));
     }
 
-    std::vector<EdgeBoundaryType> edge_boundaries;
+    AlignedVector<EdgeBoundaryType> edge_boundaries;
 
     for (auto& bound : boundaries) {
         edge_boundaries.emplace_back(EdgeBoundaryType(bound));
@@ -127,13 +127,13 @@ int main() {
     }
 
     // generate edge intenrals
-    std::vector<InterfaceType> interfaces;
+    AlignedVector<InterfaceType> interfaces;
 
     for (auto& rb : raw_boundary[SWE::BoundaryTypes::land]) {
         interfaces.emplace_back(InterfaceType(std::move(rb.second), std::move(rb.second)));
     }
 
-    std::vector<EdgeInterfaceType> edge_interfaces;
+    AlignedVector<EdgeInterfaceType> edge_interfaces;
 
     for (auto& intface : interfaces) {
         edge_interfaces.emplace_back(EdgeInterfaceType(intface));

--- a/test/test_edges.cpp
+++ b/test/test_edges.cpp
@@ -199,10 +199,12 @@ int main() {
                                   1.e+03)) {
                     error_found = true;
 
-                    std::cout << edge_boundaries[n_bound].IntegrationPhiLambda(dof, doff, unit)[0] << ' '
+                    std::cout << std::setprecision(16)
+			      << edge_boundaries[n_bound].IntegrationPhiLambda(dof, doff, unit)[0] << ' '
                               << edge_boundaries[n_bound].IntegrationLambda(doff, u_phi_gp)[0] << std::endl;
 
-                    std::cerr << "Error found in boundary edge in IntegrationPhiLambda" << std::endl;
+                    std::cerr << "Error found in boundary edge in IntegrationPhiLambda\n"
+			      << "  dof: " << dof << " doff: " << doff << std::endl;
                 }
             }
         }

--- a/test/test_edges.cpp
+++ b/test/test_edges.cpp
@@ -200,11 +200,11 @@ int main() {
                     error_found = true;
 
                     std::cout << std::setprecision(16)
-			      << edge_boundaries[n_bound].IntegrationPhiLambda(dof, doff, unit)[0] << ' '
+                              << edge_boundaries[n_bound].IntegrationPhiLambda(dof, doff, unit)[0] << ' '
                               << edge_boundaries[n_bound].IntegrationLambda(doff, u_phi_gp)[0] << std::endl;
 
                     std::cerr << "Error found in boundary edge in IntegrationPhiLambda\n"
-			      << "  dof: " << dof << " doff: " << doff << std::endl;
+                              << "  dof: " << dof << " doff: " << doff << std::endl;
                 }
             }
         }

--- a/test/test_element_triangle.hpp
+++ b/test/test_element_triangle.hpp
@@ -270,6 +270,9 @@ bool check_for_error(ElementType& triangle, DynMatrix<double>& f_vals) {
                 error_found = true;
 
                 std::cerr << "Error found in Triangle element in IntegrationPhiPhi" << std::endl;
+		std::cerr << std::setprecision(16)
+			  << "  " << triangle.IntegrationPhi(doff, gp_vals)[0] << ' '
+			  << triangle.IntegrationPhiPhi(dof, doff, unit_gp)[0] << '\n';
             }
         }
 
@@ -282,6 +285,10 @@ bool check_for_error(ElementType& triangle, DynMatrix<double>& f_vals) {
                 error_found = true;
 
                 std::cerr << "Error found in Triangle element in IntegrationPhiDPhi" << std::endl;
+		std::cerr << std::setprecision(16)
+			  << "  " << triangle.IntegrationDPhi(GlobalCoord::x, doff, gp_vals)[0] << ' '
+			  << triangle.IntegrationPhiDPhi(dof, GlobalCoord::x, doff, unit_gp)[0] << '\n';
+
             }
 
             if (!almost_equal(triangle.IntegrationPhi(doff, gp_dvals)[0],

--- a/test/test_element_triangle.hpp
+++ b/test/test_element_triangle.hpp
@@ -270,9 +270,8 @@ bool check_for_error(ElementType& triangle, DynMatrix<double>& f_vals) {
                 error_found = true;
 
                 std::cerr << "Error found in Triangle element in IntegrationPhiPhi" << std::endl;
-		std::cerr << std::setprecision(16)
-			  << "  " << triangle.IntegrationPhi(doff, gp_vals)[0] << ' '
-			  << triangle.IntegrationPhiPhi(dof, doff, unit_gp)[0] << '\n';
+                std::cerr << std::setprecision(16) << "  " << triangle.IntegrationPhi(doff, gp_vals)[0] << ' '
+                          << triangle.IntegrationPhiPhi(dof, doff, unit_gp)[0] << '\n';
             }
         }
 
@@ -285,10 +284,8 @@ bool check_for_error(ElementType& triangle, DynMatrix<double>& f_vals) {
                 error_found = true;
 
                 std::cerr << "Error found in Triangle element in IntegrationPhiDPhi" << std::endl;
-		std::cerr << std::setprecision(16)
-			  << "  " << triangle.IntegrationDPhi(GlobalCoord::x, doff, gp_vals)[0] << ' '
-			  << triangle.IntegrationPhiDPhi(dof, GlobalCoord::x, doff, unit_gp)[0] << '\n';
-
+                std::cerr << std::setprecision(16) << "  " << triangle.IntegrationDPhi(GlobalCoord::x, doff, gp_vals)[0]
+                          << ' ' << triangle.IntegrationPhiDPhi(dof, GlobalCoord::x, doff, unit_gp)[0] << '\n';
             }
 
             if (!almost_equal(triangle.IntegrationPhi(doff, gp_dvals)[0],

--- a/test/test_shape_serialization.cpp
+++ b/test/test_shape_serialization.cpp
@@ -11,9 +11,9 @@ bool is_equal(Shape::StraightTriangle& o_tri, Shape::StraightTriangle& i_tri) {
     for (uint bd_id = 0; bd_id < 3; ++bd_id) {
         std::vector<Point<2>> test_pt{test_points[bd_id]};
 
-	using Vec = StatVector<double,2>;
-        std::vector<Vec,AlignedAllocator<Vec>> o_normal = o_tri.GetSurfaceNormal(bd_id, test_pt);
-        std::vector<Vec,AlignedAllocator<Vec>> i_normal = i_tri.GetSurfaceNormal(bd_id, test_pt);
+        using Vec                                        = StatVector<double, 2>;
+        std::vector<Vec, AlignedAllocator<Vec>> o_normal = o_tri.GetSurfaceNormal(bd_id, test_pt);
+        std::vector<Vec, AlignedAllocator<Vec>> i_normal = i_tri.GetSurfaceNormal(bd_id, test_pt);
 
         is_equal &= almost_equal(o_normal[0][0], i_normal[0][0]);
         is_equal &= almost_equal(o_normal[0][1], i_normal[0][1]);

--- a/test/test_shape_serialization.cpp
+++ b/test/test_shape_serialization.cpp
@@ -11,8 +11,9 @@ bool is_equal(Shape::StraightTriangle& o_tri, Shape::StraightTriangle& i_tri) {
     for (uint bd_id = 0; bd_id < 3; ++bd_id) {
         std::vector<Point<2>> test_pt{test_points[bd_id]};
 
-        std::vector<StatVector<double, 2>> o_normal = o_tri.GetSurfaceNormal(bd_id, test_pt);
-        std::vector<StatVector<double, 2>> i_normal = i_tri.GetSurfaceNormal(bd_id, test_pt);
+	using Vec = StatVector<double,2>;
+        std::vector<Vec,AlignedAllocator<Vec>> o_normal = o_tri.GetSurfaceNormal(bd_id, test_pt);
+        std::vector<Vec,AlignedAllocator<Vec>> i_normal = i_tri.GetSurfaceNormal(bd_id, test_pt);
 
         is_equal &= almost_equal(o_normal[0][0], i_normal[0][0]);
         is_equal &= almost_equal(o_normal[0][1], i_normal[0][1]);

--- a/test/test_shape_straight_triangle.cpp
+++ b/test/test_shape_straight_triangle.cpp
@@ -49,7 +49,7 @@ int main() {
     }
 
     // check SurfaceNormal
-    std::vector<StatVector<double, 2>> SurfaceNormal_true(3);
+    AlignedVector<StatVector<double, 2>> SurfaceNormal_true(3);
 
     SurfaceNormal_true[0][GlobalCoord::x] = std::sqrt(3.) / 2.;
     SurfaceNormal_true[0][GlobalCoord::y] = 0.5;


### PR DESCRIPTION
This pull request mainly addresses alignment issues in the RKDG SWE problem.

This is a partial reason for the failure of the unit tests observed in #119 was unaligned data access.

The blaze tests pass for all vectorization instructions on both Knights Landing and Skylake architectures.

For the eigen tests, there seems to be an unresovled issue with compiling with `-march=native` on the skylake nodes, in particular the unit tests do not pass. 