### PR TITLE
WIP: Changing data held in element to accessor data

### DIFF
--- a/source/preprocessor/initialize_mesh.hpp
+++ b/source/preprocessor/initialize_mesh.hpp
@@ -34,7 +34,7 @@ void initialize_mesh_elements(typename ProblemType::ProblemMeshType& mesh,
     MeshMetaData& mesh_data = input.mesh_input.mesh_data;
 
     using ElementType =
-        typename std::tuple_element<0, Geometry::ElementTypeTuple<typename ProblemType::ProblemDataType>>::type;
+        typename std::tuple_element<0, Geometry::ElementTypeTuple<typename ProblemType::ProblemAccessorType>>::type;
 
     for (auto& element_meta : mesh_data.elements) {
         uint elt_id = element_meta.first;
@@ -58,7 +58,7 @@ void initialize_mesh_interfaces_boundaries(typename ProblemType::ProblemMeshType
                                            typename ProblemType::ProblemInputType& problem_input,
                                            Communicator& communicator,
                                            typename ProblemType::ProblemWriterType& writer) {
-    using RawBoundaryType = Geometry::RawBoundary<1, typename ProblemType::ProblemDataType>;
+    using RawBoundaryType = Geometry::RawBoundary<1, typename ProblemType::ProblemAccessorType>;
 
     std::map<uchar, std::map<std::pair<uint, uint>, RawBoundaryType>> raw_boundaries;
 

--- a/source/problem/SWE/discretization_EHDG/data_structure/ehdg_swe_data.hpp
+++ b/source/problem/SWE/discretization_EHDG/data_structure/ehdg_swe_data.hpp
@@ -9,7 +9,7 @@
 
 namespace SWE {
 namespace EHDG {
-struct Data {
+struct Accessor {
     AlignedVector<State> state;
     Internal internal;
     AlignedVector<Boundary> boundary;

--- a/source/problem/SWE/discretization_EHDG/ehdg_swe_problem.hpp
+++ b/source/problem/SWE/discretization_EHDG/ehdg_swe_problem.hpp
@@ -36,30 +36,30 @@ struct Problem {
     using ProblemWriterType  = Writer<Problem>;
     using ProblemParserType  = SWE::Parser;
 
-    using ProblemDataType       = Data;
+    using ProblemAccessorType       = Accessor;
     using ProblemEdgeDataType   = EdgeData;
     using ProblemGlobalDataType = std::tuple<>;
 
-    using ProblemInterfaceTypes = Geometry::InterfaceTypeTuple<Data, ISP::Internal, ISP::Levee>;
-    using ProblemBoundaryTypes  = Geometry::BoundaryTypeTuple<Data, BC::Land, BC::Tide, BC::Flow, BC::Function>;
+    using ProblemInterfaceTypes = Geometry::InterfaceTypeTuple<Accessor, ISP::Internal, ISP::Levee>;
+    using ProblemBoundaryTypes  = Geometry::BoundaryTypeTuple<Accessor, BC::Land, BC::Tide, BC::Flow, BC::Function>;
     using ProblemDistributedBoundaryTypes =
-        Geometry::DistributedBoundaryTypeTuple<Data, DBC::Distributed, DBC::DistributedLevee>;
+        Geometry::DistributedBoundaryTypeTuple<Accessor, DBC::Distributed, DBC::DistributedLevee>;
 
     using ProblemEdgeInterfaceTypes = Geometry::EdgeInterfaceTypeTuple<EdgeData, ProblemInterfaceTypes>::Type;
     using ProblemEdgeBoundaryTypes  = Geometry::EdgeBoundaryTypeTuple<EdgeData, ProblemBoundaryTypes>::Type;
     using ProblemEdgeDistributedTypes =
         Geometry::EdgeDistributedTypeTuple<EdgeData, ProblemDistributedBoundaryTypes>::Type;
 
-    using ProblemMeshType = Geometry::MeshType<Data,
+    using ProblemMeshType = Geometry::MeshType<Accessor,
                                                std::tuple<ISP::Internal, ISP::Levee>,
                                                std::tuple<BC::Land, BC::Tide, BC::Flow, BC::Function>,
                                                std::tuple<DBC::Distributed, DBC::DistributedLevee>>::Type;
 
     using ProblemMeshSkeletonType = Geometry::MeshSkeletonType<
         EdgeData,
-        Geometry::InterfaceTypeTuple<Data, ISP::Internal, ISP::Levee>,
-        Geometry::BoundaryTypeTuple<Data, BC::Land, BC::Tide, BC::Flow, BC::Function>,
-        Geometry::DistributedBoundaryTypeTuple<Data, DBC::Distributed, DBC::DistributedLevee>>::Type;
+        Geometry::InterfaceTypeTuple<Accessor, ISP::Internal, ISP::Levee>,
+        Geometry::BoundaryTypeTuple<Accessor, BC::Land, BC::Tide, BC::Flow, BC::Function>,
+        Geometry::DistributedBoundaryTypeTuple<Accessor, DBC::Distributed, DBC::DistributedLevee>>::Type;
 
     using ProblemDiscretizationType = HDGDiscretization<Problem>;
 

--- a/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data.hpp
+++ b/source/problem/SWE/discretization_RKDG/data_structure/rkdg_swe_data.hpp
@@ -10,7 +10,7 @@
 
 namespace SWE {
 namespace RKDG {
-struct Data {
+struct Accessor {
     AlignedVector<State> state;
     Internal internal;
     AlignedVector<Boundary> boundary;

--- a/source/problem/SWE/discretization_RKDG/rkdg_swe_problem.hpp
+++ b/source/problem/SWE/discretization_RKDG/rkdg_swe_problem.hpp
@@ -31,14 +31,15 @@ struct Problem {
     using ProblemWriterType  = Writer<Problem>;
     using ProblemParserType  = SWE::Parser;
 
-    using ProblemDataType = Data;
+    using ProblemAccessorType = Accessor;
+    //using ProblemSoAType  = SoAContainer
 
-    using ProblemInterfaceTypes = Geometry::InterfaceTypeTuple<Data, ISP::Internal, ISP::Levee>;
-    using ProblemBoundaryTypes  = Geometry::BoundaryTypeTuple<Data, BC::Land, BC::Tide, BC::Flow, BC::Function>;
+    using ProblemInterfaceTypes = Geometry::InterfaceTypeTuple<Accessor, ISP::Internal, ISP::Levee>;
+    using ProblemBoundaryTypes  = Geometry::BoundaryTypeTuple<Accessor, BC::Land, BC::Tide, BC::Flow, BC::Function>;
     using ProblemDistributedBoundaryTypes =
-        Geometry::DistributedBoundaryTypeTuple<Data, DBC::Distributed, DBC::DistributedLevee>;
+        Geometry::DistributedBoundaryTypeTuple<Accessor, DBC::Distributed, DBC::DistributedLevee>;
 
-    using ProblemMeshType = Geometry::MeshType<Data,
+    using ProblemMeshType = Geometry::MeshType<Accessor,
                                                std::tuple<ISP::Internal, ISP::Levee>,
                                                std::tuple<BC::Land, BC::Tide, BC::Flow, BC::Function>,
                                                std::tuple<DBC::Distributed, DBC::DistributedLevee>>::Type;

--- a/test/test_boundary_interface.cpp
+++ b/test/test_boundary_interface.cpp
@@ -12,12 +12,12 @@ int main() {
 
     using MasterType  = Master::Triangle<Basis::Dubiner_2D, Integration::Dunavant_2D>;
     using ShapeType   = Shape::StraightTriangle;
-    using ElementType = Geometry::Element<2, MasterType, ShapeType, SWE::RKDG::Data>;
+    using ElementType = Geometry::Element<2, MasterType, ShapeType, SWE::RKDG::Accessor>;
 
-    using RawBoundaryType = Geometry::RawBoundary<1, SWE::RKDG::Data>;
-    using BoundaryType    = Geometry::Boundary<1, Integration::GaussLegendre_1D, SWE::RKDG::Data, SWE::RKDG::BC::Land>;
+    using RawBoundaryType = Geometry::RawBoundary<1, SWE::RKDG::Accessor>;
+    using BoundaryType    = Geometry::Boundary<1, Integration::GaussLegendre_1D, SWE::RKDG::Accessor, SWE::RKDG::BC::Land>;
     using InterfaceType =
-        Geometry::Interface<1, Integration::GaussLegendre_1D, SWE::RKDG::Data, SWE::RKDG::ISP::Internal>;
+        Geometry::Interface<1, Integration::GaussLegendre_1D, SWE::RKDG::Accessor, SWE::RKDG::ISP::Internal>;
 
     // make an equilateral triangle
     std::vector<Point<3>> vrtxs(3);

--- a/test/test_edges.cpp
+++ b/test/test_edges.cpp
@@ -15,21 +15,21 @@ int main() {
 
     using MasterType  = Master::Triangle<Basis::Dubiner_2D, Integration::Dunavant_2D>;
     using ShapeType   = Shape::StraightTriangle;
-    using ElementType = Geometry::Element<2, MasterType, ShapeType, SWE::EHDG::Data>;
+    using ElementType = Geometry::Element<2, MasterType, ShapeType, SWE::EHDG::Accessor>;
 
-    using RawBoundaryType = Geometry::RawBoundary<1, SWE::EHDG::Data>;
-    using BoundaryType    = Geometry::Boundary<1, Integration::GaussLegendre_1D, SWE::EHDG::Data, SWE::EHDG::BC::Land>;
+    using RawBoundaryType = Geometry::RawBoundary<1, SWE::EHDG::Accessor>;
+    using BoundaryType    = Geometry::Boundary<1, Integration::GaussLegendre_1D, SWE::EHDG::Accessor, SWE::EHDG::BC::Land>;
     using InterfaceType =
-        Geometry::Interface<1, Integration::GaussLegendre_1D, SWE::EHDG::Data, SWE::EHDG::ISP::Internal>;
+        Geometry::Interface<1, Integration::GaussLegendre_1D, SWE::EHDG::Accessor, SWE::EHDG::ISP::Internal>;
 
     using EdgeBoundaryTypes =
         Geometry::EdgeBoundaryTypeTuple<SWE::EHDG::EdgeData,
-                                        Geometry::BoundaryTypeTuple<SWE::EHDG::Data, SWE::EHDG::BC::Land>>::Type;
+                                        Geometry::BoundaryTypeTuple<SWE::EHDG::Accessor, SWE::EHDG::BC::Land>>::Type;
     using EdgeBoundaryType = typename std::tuple_element<0, EdgeBoundaryTypes>::type;
 
     using EdgeInterfaceTypes =
         Geometry::EdgeInterfaceTypeTuple<SWE::EHDG::EdgeData,
-                                         Geometry::InterfaceTypeTuple<SWE::EHDG::Data, SWE::EHDG::ISP::Internal>>::Type;
+                                         Geometry::InterfaceTypeTuple<SWE::EHDG::Accessor, SWE::EHDG::ISP::Internal>>::Type;
     using EdgeInterfaceType = typename std::tuple_element<0, EdgeInterfaceTypes>::type;
 
     // make an equilateral triangle

--- a/test/test_element_triangle.hpp
+++ b/test/test_element_triangle.hpp
@@ -10,7 +10,7 @@
 
 using MasterType  = Master::Triangle<Basis::Dubiner_2D, Integration::Dunavant_2D>;
 using ShapeType   = Shape::StraightTriangle;
-using ElementType = Geometry::Element<2, MasterType, ShapeType, SWE::RKDG::Data>;
+using ElementType = Geometry::Element<2, MasterType, ShapeType, SWE::RKDG::Accessor>;
 
 using Utilities::almost_equal;
 

--- a/test/test_wetting_drying.cpp
+++ b/test/test_wetting_drying.cpp
@@ -18,7 +18,7 @@ int main() {
 
     using MasterType  = Master::Triangle<Basis::Dubiner_2D, Integration::Dunavant_2D>;
     using ShapeType   = Shape::StraightTriangle;
-    using ElementType = Geometry::Element<2, MasterType, ShapeType, SWE::RKDG::Data>;
+    using ElementType = Geometry::Element<2, MasterType, ShapeType, SWE::RKDG::Accessor>;
 
     // the whole test is designed for h_0 = 0.01
     SWE::PostProcessing::h_o = 0.01;


### PR DESCRIPTION
To optimize cache usage and partially enable vectorization, this PR converts the data from an array of structs layout (AoS) to a struct of arrays layout (SoA). To maintain the ease of use associated with the AoS layout, we are introducing an `Accessor` class, which will serve as a reference to the data associated with a given element.