### PR TITLE
OMPI and partitioner fixes

### DIFF
--- a/partitioner/csrmat.hpp
+++ b/partitioner/csrmat.hpp
@@ -236,6 +236,12 @@ std::vector<int64_t> metis_part(const CSRMat& mat, int64_t nparts, const double 
         return std::vector<int64_t>(nvtxs, 0);
     }
 
+    if (nvtxs == 0) {
+        std::vector<int64_t> part(nvtxs);
+        std::iota(part.begin(), part.end(), 0);
+        return part;
+    }
+
     // set up metis parameters
     int64_t ncon = static_cast<int64_t>(mat.constraint_number());
     int64_t objval;

--- a/source/simulation/ompi/simulation_ompi.hpp
+++ b/source/simulation/ompi/simulation_ompi.hpp
@@ -1,6 +1,8 @@
 #ifndef SIMULATION_OMPI_HPP
 #define SIMULATION_OMPI_HPP
 
+#include <omp.h>
+
 #include "general_definitions.hpp"
 #include "preprocessor/input_parameters.hpp"
 #include "utilities/file_exists.hpp"
@@ -51,6 +53,16 @@ OMPISimulation<ProblemType>::OMPISimulation(const std::string& input_string) {
 
 template <typename ProblemType>
 void OMPISimulation<ProblemType>::Run() {
+    if ( this->sim_units.size() ==0 ) {
+        int locality_id;
+        MPI_Comm_rank(MPI_COMM_WORLD, &locality_id);
+
+        std::cerr << "Warning: MPI Rank " << locality_id << " has not been assigned any work. This may inidicate\n"
+                  << "         poor partitioning and imply degraded performance." << std::endl;
+
+        return;
+    }
+
 #pragma omp parallel
     {
         uint n_threads, thread_id, sim_per_thread, begin_sim_id, end_sim_id;


### PR DESCRIPTION
- When partitioning n vertices into n partitions, we now return an enumeration of the vertices as the partition.
- `OMPISimulation<ProblemType>::Run()` will now immediately return if `sim_units.size()==0`.
- Fixes #137