### PR TITLE
[TMP Fix] Intel MPI TAG overflow and HPX build compiler selection

### DIFF
--- a/scripts/build/build-hpx.sh
+++ b/scripts/build/build-hpx.sh
@@ -123,7 +123,14 @@ if [ ! -d "$HPX_BUILD_PATH" ]; then
                  -DHPX_WITH_ITTNOTIFY=On \
                  -DAMPLIFIER_ROOT=${VTUNE_DIR}"
     fi
-
+    if [ -v CXX_COMPILER ]; then
+    CMAKE_FLAGS="$CMAKE_FLAGS \
+                 -DCMAKE_CXX_COMPILER=${CXX_COMPILER}"
+    fi
+    if [ -v C_COMPILER ]; then
+    CMAKE_FLAGS="$CMAKE_FLAGS \
+                 -DCMAKE_C_COMPILER=${C_COMPILER}"
+    fi
     CMD="cmake ${CMAKE_FLAGS} $HPX_REPO_PATH"
     echo "CMD = $CMD"
 

--- a/source/communication/ompi_communicator.cpp
+++ b/source/communication/ompi_communicator.cpp
@@ -10,9 +10,9 @@ OMPICommunicator::OMPICommunicator(const DistributedBoundaryMetaData& db_data) {
         rank_boundary.receive_rank = rb_meta_data.locality_ex;
 
         rank_boundary.send_tag =
-            (int)((unsigned short)rb_meta_data.submesh_in << 16 | (unsigned short)rb_meta_data.submesh_ex);
+            (int)((unsigned short)rb_meta_data.submesh_in << 8 | (unsigned short)rb_meta_data.submesh_ex);
         rank_boundary.receive_tag =
-            (int)((unsigned short)rb_meta_data.submesh_ex << 16 | (unsigned short)rb_meta_data.submesh_in);
+            (int)((unsigned short)rb_meta_data.submesh_ex << 8 | (unsigned short)rb_meta_data.submesh_in);
 
         this->rank_boundaries.push_back(std::move(rank_boundary));
     }


### PR DESCRIPTION
[Issue 1]

Intel MPI Tag is limited to 2^16, tag calculation excedes the limit.
Temporarily changed change shift to 8 instead of 16, this limits the maximum number of sub meshes to 256, need a better solution.

[Issue 2]
HPX build script did not use the compiler defined in config.

