### PR TITLE
Build system fixes

### DIFF
--- a/scripts/build/build-blaze.sh
+++ b/scripts/build/build-blaze.sh
@@ -3,44 +3,10 @@
 START_BOLD="tput bold"
 END_BOLD="tput sgr0"
 
-usage () {
-    echo "usage: $0 [options]"
-    echo "options:"
-    echo "    -h"
-    echo "        shows this message"
-    echo "    -c <config_file> "
-    echo "        specify a config file."
-    echo "        default config file is config.txt"
-    echo "    clean"
-    echo "        removes build directory."
-    echo "    no-make"
-    echo "        runs CMake, does not run make."
-    echo "    reinstall"
-    echo "        if already built, reinstalls into install dir."
-    exit 1
-}
-
-CONFIGFILE=""
-
-if [ "$#" -gt 2 ]; then usage; fi
-
-if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
-    CONFIGFILE=$2
-fi
-
-if [ "$1" == "-h" ]; then usage; fi
-if [ "$1" == "--help" ]; then usage; fi
-
-# Fix me: handle more options
-if [ "$#" -gt 0 ]; then
-    if [ "$1" != "clean" ] && [ "$1" != "no-make" ] && [ "$1" != "reinstall"]; then
-	echo "invalid option: $1"
-	usage
-    fi
-fi
-
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 source $SCRIPTPATH/util.sh
+
+parse_args "$@"
 
 if [ -z "$CONFIGFILE" ]; then
     CONFIGFILE=${SCRIPTPATH}/config.txt
@@ -71,7 +37,8 @@ if [ ! -d "$BLAZE_BUILD_PATH" ]; then
     mkdir build
     cd build
     CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-                 -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH}"
+                 -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH}
+                 -DBLAZE_SHARED_MEMORY_PARALLELIZATION=OFF"
     if [ -v CXX_COMPILER ]; then
     CMAKE_FLAGS="$CMAKE_FLAGS \
                  -DCMAKE_CXX_COMPILER=${CXX_COMPILER}"

--- a/scripts/build/build-boost.sh
+++ b/scripts/build/build-boost.sh
@@ -3,41 +3,10 @@
 START_BOLD="tput bold"
 END_BOLD="tput sgr0"
 
-usage () {
-    echo "usage: $0 [options]"
-    echo "options:"
-    echo "    -h"
-    echo "        shows this message"
-    echo "    -c <config_file> "
-    echo "        specify a config file."
-    echo "        default config file is config.txt"
-    echo "    clean"
-    echo "        removes build directory."
-    echo "    no-make"
-    echo "        runs CMake, does not run make."
-    exit 1
-}
-
-CONFIGFILE=""
-
-if [ "$#" -gt 2 ]; then usage; fi
-
-if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
-    CONFIGFILE=$2
-fi
-
-if [ "$1" == "-h" ]; then usage; fi
-if [ "$1" == "--help" ]; then usage; fi
-
-if [ "$#" -gt 0 ]; then
-    if [ "$1" != "clean" ] && [ "$1" != "no-make" ]; then
-	echo "invalid option: $1"
-	usage
-    fi
-fi
-
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 source $SCRIPTPATH/util.sh
+
+parse_args "$@"
 
 if [ -z "$CONFIGFILE" ]; then
     CONFIGFILE=${SCRIPTPATH}/config.txt

--- a/scripts/build/build-eigen.sh
+++ b/scripts/build/build-eigen.sh
@@ -3,44 +3,10 @@
 START_BOLD="tput bold"
 END_BOLD="tput sgr0"
 
-usage () {
-    echo "usage: $0 [options]"
-    echo "options:"
-    echo "    -h"
-    echo "        shows this message"
-    echo "    -c <config_file> "
-    echo "        specify a config file."
-    echo "        default config file is config.txt"
-    echo "    clean"
-    echo "        removes build directory."
-    echo "    no-make"
-    echo "        runs CMake, does not run make."
-    echo "    reinstall"
-    echo "        if already built, reinstalls into install dir."
-    exit 1
-}
-
-CONFIGFILE=""
-
-if [ "$#" -gt 2 ]; then usage; fi
-
-if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
-    CONFIGFILE=$2
-fi
-
-if [ "$1" == "-h" ]; then usage; fi
-if [ "$1" == "--help" ]; then usage; fi
-
-# Fix me: handle more options
-if [ "$#" -gt 0 ]; then
-    if [ "$1" != "clean" ] && [ "$1" != "no-make" ] && [ "$1" != "reinstall"]; then
-	echo "invalid option: $1"
-	usage
-    fi
-fi
-
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 source $SCRIPTPATH/util.sh
+
+parse_args "$@"
 
 if [ -z "$CONFIGFILE" ]; then
     CONFIGFILE=${SCRIPTPATH}/config.txt

--- a/scripts/build/build-hpx.sh
+++ b/scripts/build/build-hpx.sh
@@ -3,44 +3,10 @@
 START_BOLD="tput bold"
 END_BOLD="tput sgr0"
 
-usage () {
-    echo "usage: $0 [options]"
-    echo "options:"
-    echo "    -h"
-    echo "        shows this message"
-    echo "    -c <config_file> "
-    echo "        specify a config file."
-    echo "        default config file is config.txt"
-    echo "    clean"
-    echo "        removes build directory."
-    echo "    no-make"
-    echo "        runs CMake, does not run make."
-    echo "    reinstall"
-    echo "        if already built, reinstalls into install dir."
-    exit 1
-}
-
-CONFIGFILE=""
-
-if [ "$#" -gt 2 ]; then usage; fi
-
-if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
-    CONFIGFILE=$2
-fi
-
-if [ "$1" == "-h" ]; then usage; fi
-if [ "$1" == "--help" ]; then usage; fi
-
-# Fix me: handle more options
-if [ "$#" -gt 0 ]; then
-    if [ "$1" != "clean" ] && [ "$1" != "no-make" ] && [ "$1" != "reinstall"]; then
-	echo "invalid option: $1"
-	usage
-    fi
-fi
-
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 source $SCRIPTPATH/util.sh
+
+parse_args "$@"
 
 if [ -z "$CONFIGFILE" ]; then
     CONFIGFILE=${SCRIPTPATH}/config.txt
@@ -108,8 +74,7 @@ if [ ! -d "$HPX_BUILD_PATH" ]; then
                  -DHPX_WITH_THREAD_IDLE_RATES=${IDLE_RATES} \
                  -DHPX_WITH_CXX14=On \
                  -DHPX_WITH_TESTS=Off \
-                 -DHPX_WITH_EXAMPLES=Off \
-                 -DMPI_CXX_SKIP_MPICXX=true"
+                 -DHPX_WITH_EXAMPLES=Off"
     if [ $MACHINE = "stampede2-skx" ]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} \
                  -DHPX_WITH_MORE_THAN_64_THREADS=On \

--- a/scripts/build/build-hwloc.sh
+++ b/scripts/build/build-hwloc.sh
@@ -3,44 +3,10 @@
 START_BOLD="tput bold"
 END_BOLD="tput sgr0"
 
-usage () {
-    echo "usage: $0 [options]"
-    echo "options:"
-    echo "    -h"
-    echo "        shows this message"
-    echo "    -c <config_file> "
-    echo "        specify a config file."
-    echo "        default config file is config.txt"
-    echo "    clean"
-    echo "        removes build directory."
-    echo "    no-make"
-    echo "        runs CMake, does not run make."
-    echo "    reinstall"
-    echo "        if already built, reinstalls into install dir."
-    exit 1
-}
-
-CONFIGFILE=""
-
-if [ "$#" -gt 2 ]; then usage; fi
-
-if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
-    CONFIGFILE=$2
-fi
-
-if [ "$1" == "-h" ]; then usage; fi
-if [ "$1" == "--help" ]; then usage; fi
-
-# Fix me: handle more options
-if [ "$#" -gt 0 ]; then
-    if [ "$1" != "clean" ] && [ "$1" != "no-make" ] && [ "$1" != "reinstall"]; then
-	echo "invalid option: $1"
-	usage
-    fi
-fi
-
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 source $SCRIPTPATH/util.sh
+
+parse_args "$@"
 
 if [ -z "$CONFIGFILE" ]; then
     CONFIGFILE=${SCRIPTPATH}/config.txt

--- a/scripts/build/build-jemalloc.sh
+++ b/scripts/build/build-jemalloc.sh
@@ -3,41 +3,10 @@
 START_BOLD="tput bold"
 END_BOLD="tput sgr0"
 
-usage () {
-    echo "usage: $0 [options]"
-    echo "options:"
-    echo "    -h"
-    echo "        shows this message"
-    echo "    -c <config_file> "
-    echo "        specify a config file."
-    echo "        default config file is config.txt"
-    echo "    clean"
-    echo "        removes build directory."
-    echo "    no-make"
-    echo "        runs CMake, does not run make."
-    exit 1
-}
-
-CONFIGFILE=""
-
-if [ "$#" -gt 2 ]; then usage; fi
-
-if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
-    CONFIGFILE=$2
-fi
-
-if [ "$1" == "-h" ]; then usage; fi
-if [ "$1" == "--help" ]; then usage; fi
-
-if [ "$#" -gt 0 ]; then
-    if [ "$1" != "clean" ] && [ "$1" != "no-make" ]; then
-	echo "invalid option: $1"
-	usage
-    fi
-fi
-
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 source $SCRIPTPATH/util.sh
+
+parse_args "$@"
 
 if [ -z "$CONFIGFILE" ]; then
     CONFIGFILE=${SCRIPTPATH}/config.txt

--- a/scripts/build/build-metis.sh
+++ b/scripts/build/build-metis.sh
@@ -3,44 +3,10 @@
 START_BOLD="tput bold"
 END_BOLD="tput sgr0"
 
-usage () {
-    echo "usage: $0 [options]"
-    echo "options:"
-    echo "    -h"
-    echo "        shows this message"
-    echo "    -c <config_file> "
-    echo "        specify a config file."
-    echo "        default config file is config.txt"
-    echo "    clean"
-    echo "        removes build directory."
-    echo "    no-make"
-    echo "        runs CMake, does not run make."
-    echo "    reinstall"
-    echo "        if already built, reinstalls into install dir."
-    exit 1
-}
-
-CONFIGFILE=""
-
-if [ "$#" -gt 2 ]; then usage; fi
-
-if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
-    CONFIGFILE=$2
-fi
-
-if [ "$1" == "-h" ]; then usage; fi
-if [ "$1" == "--help" ]; then usage; fi
-
-# Fix me: handle more options
-if [ "$#" -gt 0 ]; then
-    if [ "$1" != "clean" ] && [ "$1" != "no-make" ] && [ "$1" != "reinstall"]; then
-	echo "invalid option: $1"
-	usage
-    fi
-fi
-
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 source $SCRIPTPATH/util.sh
+
+parse_args "$@"
 
 if [ -z "$CONFIGFILE" ]; then
     CONFIGFILE=${SCRIPTPATH}/config.txt

--- a/scripts/build/build-yaml-cpp.sh
+++ b/scripts/build/build-yaml-cpp.sh
@@ -3,44 +3,10 @@
 START_BOLD="tput bold"
 END_BOLD="tput sgr0"
 
-usage () {
-    echo "usage: $0 [options]"
-    echo "options:"
-    echo "    -h"
-    echo "        shows this message"
-    echo "    -c <config_file> "
-    echo "        specify a config file."
-    echo "        default config file is config.txt"
-    echo "    clean"
-    echo "        removes build directory."
-    echo "    no-make"
-    echo "        runs CMake, does not run make."
-    echo "    reinstall"
-    echo "        if already built, reinstalls into install dir."
-    exit 1
-}
-
-CONFIGFILE=""
-
-if [ "$#" -gt 2 ]; then usage; fi
-
-if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
-    CONFIGFILE=$2
-fi
-
-if [ "$1" == "-h" ]; then usage; fi
-if [ "$1" == "--help" ]; then usage; fi
-
-# Fix me: handle more options
-if [ "$#" -gt 0 ]; then
-    if [ "$1" != "clean" ] && [ "$1" != "no-make" ] && [ "$1" != "reinstall"]; then
-	echo "invalid option: $1"
-	usage
-    fi
-fi
-
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 source $SCRIPTPATH/util.sh
+
+parse_args "$@"
 
 if [ -z "$CONFIGFILE" ]; then
     CONFIGFILE=${SCRIPTPATH}/config.txt

--- a/scripts/build/util.sh
+++ b/scripts/build/util.sh
@@ -1,6 +1,53 @@
  #!/bin/bash
 
 ################################################################################
+# print usage information
+# Inputs:
+#   1. script name
+function usage {
+    echo "usage: $0 [options]"
+    echo "options:"
+    echo "    -h"
+    echo "        shows this message"
+    echo "    -c <config_file> "
+    echo "        specify a config file."
+    echo "        default config file is config.txt"
+    echo "    clean"
+    echo "        removes build directory."
+    echo "    no-make"
+    echo "        runs CMake, does not run make."
+    echo "    reinstall"
+    echo "        if already built, reinstalls into install dir."
+    exit 1
+}
+
+################################################################################
+# parses inputs to build scripts (looking for correctness)
+# Inputs:
+#  1. Simply pass all command line arguments with "$@"
+# Outputs:
+#  1. Sets CONFIGFILE
+function parse_args {
+    CONFIGFILE=""
+
+    if [ "$#" -gt 2 ]; then usage; fi
+
+    if [ "$#" == 2 ] && [ "$1" == "-c" ]; then
+        CONFIGFILE=$2
+        return
+    fi
+
+    if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then usage; fi
+
+    # Fix me: handle more options
+    if [ "$#" -gt 0 ]; then
+        if [ "$1" != "clean" ] && [ "$1" != "no-make" ] && [ "$1" != "reinstall" ]; then
+	    echo "invalid option: $1"
+	    usage
+        fi
+    fi
+}
+################################################################################
 # see if system supports modules and if so load modules specified in $MODULES
 #Inputs:
 # 1. Space delimited string of modules to be loaded


### PR DESCRIPTION
- Reducing code duplication by introducing a `parse_args` function to `util.sh`
- Turning off shared memory parallelization for Blaze
- Removing `MPI_CXX_SKIP_MPICXX` from hpx build. Seems to no longer be an issue.