### PR TITLE
Updating build system for new Oden desktops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             cmake \
                 -DCMAKE_PREFIX_PATH=/usr/install \
                 -DCMAKE_BUILD_TYPE=Debug \
-                -DSET_VERBOSE=On \
+                -DCMAKE_VERBOSE_MAKEFILE=On \
                 -DCOMPILER_WARNINGS=On \
                 -DUSE_OMPI=On \
                 -DUSE_HPX=On \
@@ -58,7 +58,7 @@ jobs:
             cmake \
                 -DCMAKE_PREFIX_PATH=/usr/install \
                 -DCMAKE_BUILD_TYPE=Debug \
-                -DSET_VERBOSE=On \
+                -DCMAKE_VERBOSE_MAKEFILE=On \
                 -DCOMPILER_WARNINGS=On \
                 -DUSE_OMPI=On \
                 -DUSE_HPX=On \
@@ -142,7 +142,7 @@ jobs:
             cmake \
                 -DCMAKE_PREFIX_PATH=/usr/install \
                 -DCMAKE_BUILD_TYPE=Debug \
-                -DSET_VERBOSE=On \
+                -DCMAKE_VERBOSE_MAKEFILE=On \
                 -DCOMPILER_WARNINGS=On \
                 -DUSE_OMPI=On \
                 -DUSE_HPX=On \
@@ -165,7 +165,7 @@ jobs:
                 -DCMAKE_PREFIX_PATH=/usr/install \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DSET_VERBOSE=On \
-                -DCOMPILER_WARNINGS=On \
+                -DCMAKE_VERBOSE_MAKEFILE=On \
                 -DUSE_OMPI=On \
                 -DUSE_HPX=On \
                 -DRKDG=On \

--- a/scripts/build/build-boost.sh
+++ b/scripts/build/build-boost.sh
@@ -37,9 +37,9 @@ if [ ! -d ${BOOST_BUILD} ]; then
     set -e
     mkdir -p ${BOOST_BUILD}
     cd ${BOOST_BUILD}
-    wget 'http://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2'
-    tar xf boost_1_63_0.tar.bz2
-    cd boost_1_63_0
+    wget 'https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2'
+    tar xf boost_1_69_0.tar.bz2
+    cd boost_1_69_0
     ./bootstrap.sh --prefix="$INSTALL_PATH"
     ./b2 -j${NUM_BUILDCORES} install
     exit

--- a/scripts/build/build-metis.sh
+++ b/scripts/build/build-metis.sh
@@ -31,7 +31,13 @@ if [ ! -d "$METIS_BUILD_PATH" ]; then
     set -e
     mkdir -p ${METIS_BUILD_PATH}
     cd ${METIS_BUILD_PATH}
-    wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz
+
+    { #try pulling from metis website
+        wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz
+    } || { #otherwise pull from the fedora mirror
+        wget http://pkgs.fedoraproject.org/repo/pkgs/metis/metis-5.1.0.tar.gz/md5/5465e67079419a69e0116de24fce58fe/metis-5.1.0.tar.gz
+    }
+
     tar xf metis-5.1.0.tar.gz
     cd metis-5.1.0
     sed -i 's/#define IDXTYPEWIDTH 32/#define IDXTYPEWIDTH 64/g' include/metis.h

--- a/scripts/build/config.txt
+++ b/scripts/build/config.txt
@@ -2,11 +2,10 @@ BUILD_TYPE=Release
 MACHINE=stampede2-knl
 #VERBOSE=true
 
-if [ "$MACHINE" == "ices-desktop" ]; then
-   echo "using ices-desktop"
+if [ "$MACHINE" == "oden-desktop" ]; then
+   echo "using oden-desktop"
     NUM_BUILDCORES=4
-    MODULES="c7 gcc/8.1 cmake/3.10.2 boost/1.67.0 mpich/1.2.7p1"
-    CMAKE="/opt/apps/ossw/applications/cmake/cmake-3.10.2/c7/gcc-8.1/bin/cmake"
+    MODULES="ubt18 gcc/8.2 mpich2/3.2 mkl/19.0 petsc/3.9.3-cxx-opt"
 
     WORK=/workspace/bremer
 fi

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -46,8 +46,8 @@ if(USE_HPX)
   hpx_setup_target(
     dgswemv2-hpx
     COMPONENT_DEPENDENCIES iostreams
+    DEPENDENCIES ${YAML_CPP_LIBRARIES}
   )
-  target_include_directories(dgswemv2-hpx PRIVATE ${YAML_CPP_INCLUDE_DIR} ${HPX_INCLUDE_DIRS})  
-  target_link_libraries(dgswemv2-hpx ${YAML_CPP_LIBRARIES} ${HPX_LIBRARIES})
+  target_include_directories(dgswemv2-hpx PRIVATE ${YAML_CPP_INCLUDE_DIR} ${HPX_INCLUDE_DIRS})
   install(TARGETS dgswemv2-hpx DESTINATION bin)
 endif()

--- a/source/dgswemv2-hpx.cpp
+++ b/source/dgswemv2-hpx.cpp
@@ -2,7 +2,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/iostreams.hpp>
-#include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
 
 #include "general_definitions.hpp"

--- a/source/simulation/hpx/sim_unit_hpx_base.hpp
+++ b/source/simulation/hpx/sim_unit_hpx_base.hpp
@@ -4,6 +4,8 @@
 #include "general_definitions.hpp"
 #include "utilities/is_defined.hpp"
 
+#include <hpx/include/components.hpp>
+
 struct HPXSimulationUnitBase
     //    : public hpx::components::migration_support<hpx::components::component_base<HPXSimulationUnit<ProblemType>>> {
     : public hpx::components::abstract_managed_component_base<HPXSimulationUnitBase> {

--- a/test/test_serialize_chrono.cpp
+++ b/test/test_serialize_chrono.cpp
@@ -1,4 +1,4 @@
-#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/serialization/serialize.hpp>
 #include "utilities/serialize_chrono.hpp"
 
 #include <iostream>

--- a/test/test_serialize_chrono.cpp
+++ b/test/test_serialize_chrono.cpp
@@ -1,4 +1,4 @@
-#include <hpx/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/serialize.hpp>
 #include "utilities/serialize_chrono.hpp"
 
 #include <iostream>


### PR DESCRIPTION
- Boost version upgraded to 1.69.0 (you need to build this manually
  anyway)
- Added additional website for metis incase the Metis website is down
- Various HPX related fixes associated with using the latest version
- Updating deprecated headers